### PR TITLE
Merge `Signer`/`Verifier`/`Signature`/`Digest` into `SessionParameters`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - `Session` is now generic over `SessionParameters` instead of a bunch of separate types. ([#36])
+- `MessageBundle` is not generic anymore. ([#36])
 
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.0.2] - In development
 
+### Changed
+
+- `Session` is now generic over `SessionParameters` instead of a bunch of separate types. ([#36])
+
+
 ### Added
 
 - `SerializableMap` wrapper for `BTreeMap` supporting more formats and providing some safety features. (#[32])
 
 
 [#32]: https://github.com/entropyxyz/manul/pull/32
+[#36]: https://github.com/entropyxyz/manul/pull/36
 
 
 ## [0.0.1] - 2024-10-12

--- a/example/src/simple.rs
+++ b/example/src/simple.rs
@@ -4,7 +4,6 @@ use core::fmt::Debug;
 use manul::protocol::*;
 use rand_core::CryptoRngCore;
 use serde::{Deserialize, Serialize};
-use sha3::Sha3_256;
 use tracing::debug;
 
 #[derive(Debug)]
@@ -72,8 +71,6 @@ impl Protocol for SimpleProtocol {
     type Result = u8;
     type ProtocolError = SimpleProtocolError;
     type CorrectnessProof = ();
-
-    type Digest = Sha3_256;
 
     fn serialize<T: Serialize>(value: T) -> Result<Box<[u8]>, LocalError> {
         bincode::serde::encode_to_vec(value, bincode::config::standard())
@@ -359,7 +356,7 @@ mod tests {
 
     use manul::{
         session::{signature::Keypair, SessionOutcome},
-        testing::{run_sync, Signature, Signer, Verifier},
+        testing::{run_sync, Signer, TestingSessionParams, Verifier},
     };
     use rand_core::OsRng;
     use tracing_subscriber::EnvFilter;
@@ -389,7 +386,7 @@ mod tests {
             .with_env_filter(EnvFilter::from_default_env())
             .finish();
         let reports = tracing::subscriber::with_default(my_subscriber, || {
-            run_sync::<Round1<Verifier>, Signer, Verifier, Signature>(&mut OsRng, inputs).unwrap()
+            run_sync::<Round1<Verifier>, TestingSessionParams>(&mut OsRng, inputs).unwrap()
         });
 
         for (_id, report) in reports {

--- a/example/src/simple_malicious.rs
+++ b/example/src/simple_malicious.rs
@@ -6,7 +6,7 @@ use manul::{
         Artifact, DirectMessage, FinalizeError, FinalizeOutcome, FirstRound, LocalError, Payload, Round, SessionId,
     },
     session::signature::Keypair,
-    testing::{round_override, run_sync, RoundOverride, RoundWrapper, Signature, Signer, Verifier},
+    testing::{round_override, run_sync, RoundOverride, RoundWrapper, Signer, TestingSessionParams, Verifier},
 };
 use rand_core::{CryptoRngCore, OsRng};
 use tracing_subscriber::EnvFilter;
@@ -172,7 +172,7 @@ fn serialized_garbage() {
         .with_env_filter(EnvFilter::from_default_env())
         .finish();
     let mut reports = tracing::subscriber::with_default(my_subscriber, || {
-        run_sync::<MaliciousRound1<Verifier>, Signer, Verifier, Signature>(&mut OsRng, run_inputs).unwrap()
+        run_sync::<MaliciousRound1<Verifier>, TestingSessionParams>(&mut OsRng, run_inputs).unwrap()
     });
 
     let v0 = signers[0].verifying_key();
@@ -218,7 +218,7 @@ fn attributable_failure() {
         .with_env_filter(EnvFilter::from_default_env())
         .finish();
     let mut reports = tracing::subscriber::with_default(my_subscriber, || {
-        run_sync::<MaliciousRound1<Verifier>, Signer, Verifier, Signature>(&mut OsRng, run_inputs).unwrap()
+        run_sync::<MaliciousRound1<Verifier>, TestingSessionParams>(&mut OsRng, run_inputs).unwrap()
     });
 
     let v0 = signers[0].verifying_key();
@@ -264,7 +264,7 @@ fn attributable_failure_round2() {
         .with_env_filter(EnvFilter::from_default_env())
         .finish();
     let mut reports = tracing::subscriber::with_default(my_subscriber, || {
-        run_sync::<MaliciousRound1<Verifier>, Signer, Verifier, Signature>(&mut OsRng, run_inputs).unwrap()
+        run_sync::<MaliciousRound1<Verifier>, TestingSessionParams>(&mut OsRng, run_inputs).unwrap()
     });
 
     let v0 = signers[0].verifying_key();

--- a/example/tests/async.rs
+++ b/example/tests/async.rs
@@ -23,12 +23,12 @@ use tracing_subscriber::{util::SubscriberInitExt, EnvFilter};
 struct MessageOut<SP: SessionParameters> {
     from: SP::Verifier,
     to: SP::Verifier,
-    message: MessageBundle<SP>,
+    message: MessageBundle,
 }
 
 struct MessageIn<SP: SessionParameters> {
     from: SP::Verifier,
-    message: MessageBundle<SP>,
+    message: MessageBundle,
 }
 
 async fn run_session<P, SP>(
@@ -185,8 +185,7 @@ where
     let (dispatcher_tx, dispatcher_rx) = mpsc::channel::<MessageOut<SP>>(100);
 
     let channels = (0..num_parties).map(|_| mpsc::channel::<MessageIn<SP>>(100));
-    #[allow(clippy::type_complexity)]
-    let (txs, rxs): (Vec<mpsc::Sender<MessageIn<SP>>>, Vec<mpsc::Receiver<MessageIn<SP>>>) = channels.unzip();
+    let (txs, rxs): (Vec<_>, Vec<_>) = channels.unzip();
     let tx_map = sessions
         .iter()
         .map(|session| session.verifier())

--- a/manul/Cargo.toml
+++ b/manul/Cargo.toml
@@ -22,7 +22,6 @@ rand = { version = "0.8", default-features = false, optional = true }
 
 [dev-dependencies]
 impls = "1"
-sha3 = "0.10"
 rand = { version = "0.8", default-features = false }
 bincode = { version = "2.0.0-rc.3", default-features = false, features = ["alloc", "serde"] }
 serde_asn1_der = "0.8"

--- a/manul/Cargo.toml
+++ b/manul/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["cryptography", "no-std"]
 
 [dependencies]
 serde = { version = "1", default-features = false, features = ["alloc", "serde_derive"] }
-serde-encoded-bytes = { version = "0.1", default-features = false, features = ["base64"] }
+serde-encoded-bytes = { version = "0.1", default-features = false, features = ["hex", "base64"] }
 digest = { version = "0.10", default-features = false }
 signature = { version = "2", default-features = false, features = ["digest", "rand_core"] }
 rand_core = { version = "0.6.4", default-features = false }

--- a/manul/benches/empty_rounds.rs
+++ b/manul/benches/empty_rounds.rs
@@ -10,7 +10,7 @@ use manul::{
         LocalError, Payload, Protocol, ProtocolError, ProtocolValidationError, ReceiveError, Round, RoundId,
     },
     session::{signature::Keypair, SessionId, SessionOutcome},
-    testing::{run_sync, Hasher, Signature, Signer, Verifier},
+    testing::{run_sync, Signer, TestingSessionParams, Verifier},
 };
 use rand_core::{CryptoRngCore, OsRng};
 use serde::{Deserialize, Serialize};
@@ -38,8 +38,6 @@ impl Protocol for EmptyProtocol {
     type Result = ();
     type ProtocolError = EmptyProtocolError;
     type CorrectnessProof = ();
-
-    type Digest = Hasher;
 
     fn serialize<T: Serialize>(value: T) -> Result<Box<[u8]>, LocalError> {
         bincode::serde::encode_to_vec(value, bincode::config::standard())
@@ -206,7 +204,7 @@ fn bench_empty_rounds(c: &mut Criterion) {
     group.bench_function("25 nodes, 5 rounds, no echo", |b| {
         b.iter(|| {
             assert!(
-                run_sync::<EmptyRound<Verifier>, Signer, Verifier, Signature>(&mut OsRng, inputs_no_echo.clone())
+                run_sync::<EmptyRound<Verifier>, TestingSessionParams>(&mut OsRng, inputs_no_echo.clone())
                     .unwrap()
                     .values()
                     .all(|report| matches!(report.outcome, SessionOutcome::Result(_)))
@@ -236,7 +234,7 @@ fn bench_empty_rounds(c: &mut Criterion) {
     group.bench_function("25 nodes, 5 rounds, echo each round", |b| {
         b.iter(|| {
             assert!(
-                run_sync::<EmptyRound<Verifier>, Signer, Verifier, Signature>(&mut OsRng, inputs_echo.clone())
+                run_sync::<EmptyRound<Verifier>, TestingSessionParams>(&mut OsRng, inputs_echo.clone())
                     .unwrap()
                     .values()
                     .all(|report| matches!(report.outcome, SessionOutcome::Result(_)))

--- a/manul/src/protocol/round.rs
+++ b/manul/src/protocol/round.rs
@@ -7,7 +7,6 @@ use alloc::{
 };
 use core::{any::Any, fmt::Debug};
 
-use digest::Digest;
 use rand_core::CryptoRngCore;
 use serde::{Deserialize, Serialize};
 use serde_encoded_bytes::{Base64, SliceLike};
@@ -254,11 +253,6 @@ pub trait Protocol: Debug + Sized {
     ///
     /// It proves that the node did its job correctly, to be adjudicated by a third party.
     type CorrectnessProof: Send + Serialize + for<'de> Deserialize<'de>;
-
-    /// The hasher used by this protocol.
-    ///
-    /// This will be used to generate message signatures.
-    type Digest: Digest;
 
     /// Serializes the given object into a bytestring.
     fn serialize<T: Serialize>(value: T) -> Result<Box<[u8]>, LocalError>;

--- a/manul/src/session.rs
+++ b/manul/src/session.rs
@@ -13,7 +13,7 @@ mod transcript;
 
 pub use crate::protocol::{LocalError, RemoteError};
 pub use message::MessageBundle;
-pub use session::{CanFinalize, RoundAccumulator, RoundOutcome, Session, SessionId};
+pub use session::{CanFinalize, RoundAccumulator, RoundOutcome, Session, SessionId, SessionParameters};
 pub use transcript::{SessionOutcome, SessionReport};
 
 pub(crate) use echo::EchoRoundError;

--- a/manul/src/session/echo.rs
+++ b/manul/src/session/echo.rs
@@ -8,11 +8,11 @@ use core::fmt::Debug;
 
 use rand_core::CryptoRngCore;
 use serde::{Deserialize, Serialize};
-use signature::DigestVerifier;
 use tracing::debug;
 
 use super::{
     message::{MessageVerificationError, SignedMessage},
+    session::SessionParameters,
     LocalError,
 };
 use crate::{
@@ -30,32 +30,32 @@ pub(crate) enum EchoRoundError<Id> {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct EchoRoundMessage<Id: Debug + Clone + Ord, S> {
-    pub(crate) echo_messages: SerializableMap<Id, SignedMessage<S, EchoBroadcast>>,
+pub struct EchoRoundMessage<SP: SessionParameters> {
+    pub(crate) echo_messages: SerializableMap<SP::Verifier, SignedMessage<SP::Signature, EchoBroadcast>>,
 }
 
-pub struct EchoRound<P, Id, S> {
-    verifier: Id,
-    echo_messages: BTreeMap<Id, SignedMessage<S, EchoBroadcast>>,
-    destinations: BTreeSet<Id>,
-    expected_echos: BTreeSet<Id>,
-    main_round: Box<dyn ObjectSafeRound<Id, Protocol = P>>,
-    payloads: BTreeMap<Id, Payload>,
-    artifacts: BTreeMap<Id, Artifact>,
+pub struct EchoRound<P, SP: SessionParameters> {
+    verifier: SP::Verifier,
+    echo_messages: BTreeMap<SP::Verifier, SignedMessage<SP::Signature, EchoBroadcast>>,
+    destinations: BTreeSet<SP::Verifier>,
+    expected_echos: BTreeSet<SP::Verifier>,
+    main_round: Box<dyn ObjectSafeRound<SP::Verifier, Protocol = P>>,
+    payloads: BTreeMap<SP::Verifier, Payload>,
+    artifacts: BTreeMap<SP::Verifier, Artifact>,
 }
 
-impl<P, Id, S> EchoRound<P, Id, S>
+impl<P, SP> EchoRound<P, SP>
 where
     P: Protocol,
-    Id: Debug + Clone + Ord,
+    SP: SessionParameters,
 {
     pub fn new(
-        verifier: Id,
-        my_echo_message: SignedMessage<S, EchoBroadcast>,
-        echo_messages: BTreeMap<Id, SignedMessage<S, EchoBroadcast>>,
-        main_round: Box<dyn ObjectSafeRound<Id, Protocol = P>>,
-        payloads: BTreeMap<Id, Payload>,
-        artifacts: BTreeMap<Id, Artifact>,
+        verifier: SP::Verifier,
+        my_echo_message: SignedMessage<SP::Signature, EchoBroadcast>,
+        echo_messages: BTreeMap<SP::Verifier, SignedMessage<SP::Signature, EchoBroadcast>>,
+        main_round: Box<dyn ObjectSafeRound<SP::Verifier, Protocol = P>>,
+        payloads: BTreeMap<SP::Verifier, Payload>,
+        artifacts: BTreeMap<SP::Verifier, Artifact>,
     ) -> Self {
         let destinations = echo_messages.keys().cloned().collect::<BTreeSet<_>>();
 
@@ -79,20 +79,10 @@ where
     }
 }
 
-impl<P, Id, S> Round<Id> for EchoRound<P, Id, S>
+impl<P, SP> Round<SP::Verifier> for EchoRound<P, SP>
 where
     P: 'static + Protocol,
-    Id: 'static
-        + Debug
-        + Clone
-        + Ord
-        + Serialize
-        + for<'de> Deserialize<'de>
-        + Eq
-        + Send
-        + Sync
-        + DigestVerifier<P::Digest, S>,
-    S: 'static + Debug + Clone + Serialize + for<'de> Deserialize<'de> + Eq + Send + Sync,
+    SP: 'static + SessionParameters,
 {
     type Protocol = P;
 
@@ -104,14 +94,14 @@ where
         self.main_round.possible_next_rounds()
     }
 
-    fn message_destinations(&self) -> &BTreeSet<Id> {
+    fn message_destinations(&self) -> &BTreeSet<SP::Verifier> {
         &self.destinations
     }
 
     fn make_direct_message(
         &self,
         _rng: &mut impl CryptoRngCore,
-        destination: &Id,
+        destination: &SP::Verifier,
     ) -> Result<(DirectMessage, Artifact), LocalError> {
         debug!("{:?}: making echo round message for {:?}", self.verifier, destination);
 
@@ -124,27 +114,27 @@ where
             )));
         }
 
-        let message = EchoRoundMessage {
+        let message = EchoRoundMessage::<SP> {
             echo_messages: echo_messages.into(),
         };
         let dm = DirectMessage::new::<P, _>(&message)?;
         Ok((dm, Artifact::empty()))
     }
 
-    fn expecting_messages_from(&self) -> &BTreeSet<Id> {
+    fn expecting_messages_from(&self) -> &BTreeSet<SP::Verifier> {
         &self.destinations
     }
 
     fn receive_message(
         &self,
         _rng: &mut impl CryptoRngCore,
-        from: &Id,
+        from: &SP::Verifier,
         _echo_broadcast: Option<EchoBroadcast>,
         direct_message: DirectMessage,
-    ) -> Result<Payload, ReceiveError<Id, Self::Protocol>> {
+    ) -> Result<Payload, ReceiveError<SP::Verifier, Self::Protocol>> {
         debug!("{:?}: received an echo message from {:?}", self.verifier, from);
 
-        let message = direct_message.deserialize::<P, EchoRoundMessage<Id, S>>()?;
+        let message = direct_message.deserialize::<P, EchoRoundMessage<SP>>()?;
 
         // Check that the received message contains entries from `destinations` sans `from`
         // It is an unprovable fault.
@@ -191,7 +181,7 @@ where
                 continue;
             }
 
-            let verified_echo = match echo.clone().verify::<P, _>(sender) {
+            let verified_echo = match echo.clone().verify::<P, SP>(sender) {
                 Ok(echo) => echo,
                 Err(MessageVerificationError::Local(error)) => return Err(error.into()),
                 // This means `from` sent us an incorrectly signed message.
@@ -220,9 +210,9 @@ where
     fn finalize(
         self,
         rng: &mut impl CryptoRngCore,
-        _payloads: BTreeMap<Id, Payload>,
-        _artifacts: BTreeMap<Id, Artifact>,
-    ) -> Result<FinalizeOutcome<Id, Self::Protocol>, FinalizeError<Self::Protocol>> {
+        _payloads: BTreeMap<SP::Verifier, Payload>,
+        _artifacts: BTreeMap<SP::Verifier, Artifact>,
+    ) -> Result<FinalizeOutcome<SP::Verifier, Self::Protocol>, FinalizeError<Self::Protocol>> {
         self.main_round.finalize(rng, self.payloads, self.artifacts)
     }
 }

--- a/manul/src/session/echo.rs
+++ b/manul/src/session/echo.rs
@@ -31,12 +31,12 @@ pub(crate) enum EchoRoundError<Id> {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct EchoRoundMessage<SP: SessionParameters> {
-    pub(crate) echo_messages: SerializableMap<SP::Verifier, SignedMessage<SP::Signature, EchoBroadcast>>,
+    pub(crate) echo_messages: SerializableMap<SP::Verifier, SignedMessage<EchoBroadcast>>,
 }
 
 pub struct EchoRound<P, SP: SessionParameters> {
     verifier: SP::Verifier,
-    echo_messages: BTreeMap<SP::Verifier, SignedMessage<SP::Signature, EchoBroadcast>>,
+    echo_messages: BTreeMap<SP::Verifier, SignedMessage<EchoBroadcast>>,
     destinations: BTreeSet<SP::Verifier>,
     expected_echos: BTreeSet<SP::Verifier>,
     main_round: Box<dyn ObjectSafeRound<SP::Verifier, Protocol = P>>,
@@ -51,8 +51,8 @@ where
 {
     pub fn new(
         verifier: SP::Verifier,
-        my_echo_message: SignedMessage<SP::Signature, EchoBroadcast>,
-        echo_messages: BTreeMap<SP::Verifier, SignedMessage<SP::Signature, EchoBroadcast>>,
+        my_echo_message: SignedMessage<EchoBroadcast>,
+        echo_messages: BTreeMap<SP::Verifier, SignedMessage<EchoBroadcast>>,
         main_round: Box<dyn ObjectSafeRound<SP::Verifier, Protocol = P>>,
         payloads: BTreeMap<SP::Verifier, Payload>,
         artifacts: BTreeMap<SP::Verifier, Artifact>,

--- a/manul/src/session/message.rs
+++ b/manul/src/session/message.rs
@@ -1,15 +1,37 @@
-use alloc::format;
+use alloc::{boxed::Box, format};
 
 use digest::Digest;
 use rand_core::CryptoRngCore;
 use serde::{Deserialize, Serialize};
+use serde_encoded_bytes::{Hex, SliceLike};
 use signature::{DigestVerifier, RandomizedDigestSigner};
 
 use super::{
     session::{SessionId, SessionParameters},
     LocalError,
 };
-use crate::protocol::{DirectMessage, EchoBroadcast, Protocol, RoundId};
+use crate::protocol::{DeserializationError, DirectMessage, EchoBroadcast, Protocol, RoundId};
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct SerializedSignature(#[serde(with = "SliceLike::<Hex>")] Box<[u8]>);
+
+impl SerializedSignature {
+    pub fn new<P, SP>(signature: &SP::Signature) -> Result<Self, LocalError>
+    where
+        P: Protocol,
+        SP: SessionParameters,
+    {
+        P::serialize(signature).map(Self)
+    }
+
+    pub fn deserialize<P, SP>(&self) -> Result<SP::Signature, DeserializationError>
+    where
+        P: Protocol,
+        SP: SessionParameters,
+    {
+        P::deserialize::<SP::Signature>(&self.0)
+    }
+}
 
 #[derive(Debug, Clone)]
 pub(crate) enum MessageVerificationError {
@@ -18,8 +40,8 @@ pub(crate) enum MessageVerificationError {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub(crate) struct SignedMessage<S, M> {
-    signature: S,
+pub(crate) struct SignedMessage<M> {
+    signature: SerializedSignature,
     message_with_metadata: MessageWithMetadata<M>,
 }
 
@@ -52,7 +74,7 @@ pub struct MessageWithMetadata<M> {
     message: M,
 }
 
-impl<S, M> SignedMessage<S, M>
+impl<M> SignedMessage<M>
 where
     M: Serialize,
 {
@@ -65,7 +87,7 @@ where
     ) -> Result<Self, LocalError>
     where
         P: Protocol,
-        SP: SessionParameters<Signature = S>,
+        SP: SessionParameters,
     {
         let metadata = MessageMetadata::new(session_id, round_id);
         let message_with_metadata = MessageWithMetadata { metadata, message };
@@ -75,7 +97,7 @@ where
             .try_sign_digest_with_rng(rng, digest)
             .map_err(|err| LocalError::new(format!("Failed to sign: {:?}", err)))?;
         Ok(Self {
-            signature,
+            signature: SerializedSignature::new::<P, SP>(&signature)?,
             message_with_metadata,
         })
     }
@@ -88,17 +110,18 @@ where
         &self.message_with_metadata.message
     }
 
-    pub(crate) fn verify<P, SP>(
-        self,
-        verifier: &SP::Verifier,
-    ) -> Result<VerifiedMessage<S, M>, MessageVerificationError>
+    pub(crate) fn verify<P, SP>(self, verifier: &SP::Verifier) -> Result<VerifiedMessage<M>, MessageVerificationError>
     where
         P: Protocol,
-        SP: SessionParameters<Signature = S>,
+        SP: SessionParameters,
     {
         let message_bytes = P::serialize(&self.message_with_metadata).map_err(MessageVerificationError::Local)?;
         let digest = SP::Digest::new_with_prefix(b"SignedMessage").chain_update(message_bytes);
-        if verifier.verify_digest(digest, &self.signature).is_ok() {
+        let signature = self
+            .signature
+            .deserialize::<P, SP>()
+            .map_err(|_| MessageVerificationError::InvalidSignature)?;
+        if verifier.verify_digest(digest, &signature).is_ok() {
             Ok(VerifiedMessage {
                 signature: self.signature,
                 message_with_metadata: self.message_with_metadata,
@@ -110,12 +133,12 @@ where
 }
 
 #[derive(Debug, Clone)]
-pub struct VerifiedMessage<S, M> {
-    signature: S,
+pub struct VerifiedMessage<M> {
+    signature: SerializedSignature,
     message_with_metadata: MessageWithMetadata<M>,
 }
 
-impl<S, M> VerifiedMessage<S, M> {
+impl<M> VerifiedMessage<M> {
     pub(crate) fn metadata(&self) -> &MessageMetadata {
         &self.message_with_metadata.metadata
     }
@@ -124,7 +147,7 @@ impl<S, M> VerifiedMessage<S, M> {
         &self.message_with_metadata.message
     }
 
-    pub fn into_unverified(self) -> SignedMessage<S, M> {
+    pub fn into_unverified(self) -> SignedMessage<M> {
         SignedMessage {
             signature: self.signature,
             message_with_metadata: self.message_with_metadata,
@@ -136,25 +159,23 @@ impl<S, M> VerifiedMessage<S, M> {
 ///
 /// Note that this is already signed.
 #[derive(Clone, Debug)]
-pub struct MessageBundle<SP: SessionParameters> {
-    direct_message: SignedMessage<SP::Signature, DirectMessage>,
-    echo_broadcast: Option<SignedMessage<SP::Signature, EchoBroadcast>>,
+pub struct MessageBundle {
+    direct_message: SignedMessage<DirectMessage>,
+    echo_broadcast: Option<SignedMessage<EchoBroadcast>>,
 }
 
-impl<SP> MessageBundle<SP>
-where
-    SP: SessionParameters,
-{
-    pub(crate) fn new<P>(
+impl MessageBundle {
+    pub(crate) fn new<P, SP>(
         rng: &mut impl CryptoRngCore,
         signer: &SP::Signer,
         session_id: &SessionId,
         round_id: RoundId,
         direct_message: DirectMessage,
-        echo_broadcast: Option<SignedMessage<SP::Signature, EchoBroadcast>>,
+        echo_broadcast: Option<SignedMessage<EchoBroadcast>>,
     ) -> Result<Self, LocalError>
     where
         P: Protocol,
+        SP: SessionParameters,
     {
         let direct_message = SignedMessage::new::<P, SP>(rng, signer, session_id, round_id, direct_message)?;
         Ok(Self {
@@ -163,7 +184,7 @@ where
         })
     }
 
-    pub(crate) fn unify_metadata(self) -> Option<CheckedMessageBundle<SP>> {
+    pub(crate) fn unify_metadata(self) -> Option<CheckedMessageBundle> {
         let metadata = self.direct_message.message_with_metadata.metadata.clone();
         if !self
             .echo_broadcast
@@ -183,24 +204,22 @@ where
 }
 
 #[derive(Clone, Debug)]
-pub(crate) struct CheckedMessageBundle<SP: SessionParameters> {
+pub(crate) struct CheckedMessageBundle {
     metadata: MessageMetadata,
-    direct_message: SignedMessage<SP::Signature, DirectMessage>,
-    echo_broadcast: Option<SignedMessage<SP::Signature, EchoBroadcast>>,
+    direct_message: SignedMessage<DirectMessage>,
+    echo_broadcast: Option<SignedMessage<EchoBroadcast>>,
 }
 
-impl<SP> CheckedMessageBundle<SP>
-where
-    SP: SessionParameters,
-{
+impl CheckedMessageBundle {
     pub fn metadata(&self) -> &MessageMetadata {
         &self.metadata
     }
 
-    pub fn verify<P: Protocol>(
-        self,
-        verifier: &SP::Verifier,
-    ) -> Result<VerifiedMessageBundle<SP>, MessageVerificationError> {
+    pub fn verify<P, SP>(self, verifier: &SP::Verifier) -> Result<VerifiedMessageBundle<SP>, MessageVerificationError>
+    where
+        P: Protocol,
+        SP: SessionParameters,
+    {
         let direct_message = self.direct_message.verify::<P, SP>(verifier)?;
         let echo_broadcast = self
             .echo_broadcast
@@ -219,8 +238,8 @@ where
 pub struct VerifiedMessageBundle<SP: SessionParameters> {
     from: SP::Verifier,
     metadata: MessageMetadata,
-    direct_message: VerifiedMessage<SP::Signature, DirectMessage>,
-    echo_broadcast: Option<VerifiedMessage<SP::Signature, EchoBroadcast>>,
+    direct_message: VerifiedMessage<DirectMessage>,
+    echo_broadcast: Option<VerifiedMessage<EchoBroadcast>>,
 }
 
 impl<SP> VerifiedMessageBundle<SP>
@@ -239,13 +258,7 @@ where
         self.direct_message.payload()
     }
 
-    #[allow(clippy::type_complexity)]
-    pub(crate) fn into_unverified(
-        self,
-    ) -> (
-        Option<SignedMessage<SP::Signature, EchoBroadcast>>,
-        SignedMessage<SP::Signature, DirectMessage>,
-    ) {
+    pub(crate) fn into_unverified(self) -> (Option<SignedMessage<EchoBroadcast>>, SignedMessage<DirectMessage>) {
         let direct_message = self.direct_message.into_unverified();
         let echo_broadcast = self.echo_broadcast.map(|echo| echo.into_unverified());
         (echo_broadcast, direct_message)

--- a/manul/src/session/transcript.rs
+++ b/manul/src/session/transcript.rs
@@ -7,10 +7,9 @@ use core::fmt::Debug;
 use super::{evidence::Evidence, message::SignedMessage, session::SessionParameters, LocalError, RemoteError};
 use crate::protocol::{DirectMessage, EchoBroadcast, Protocol, RoundId};
 
-#[allow(clippy::type_complexity)]
 pub(crate) struct Transcript<P: Protocol, SP: SessionParameters> {
-    echo_broadcasts: BTreeMap<RoundId, BTreeMap<SP::Verifier, SignedMessage<SP::Signature, EchoBroadcast>>>,
-    direct_messages: BTreeMap<RoundId, BTreeMap<SP::Verifier, SignedMessage<SP::Signature, DirectMessage>>>,
+    echo_broadcasts: BTreeMap<RoundId, BTreeMap<SP::Verifier, SignedMessage<EchoBroadcast>>>,
+    direct_messages: BTreeMap<RoundId, BTreeMap<SP::Verifier, SignedMessage<DirectMessage>>>,
     provable_errors: BTreeMap<SP::Verifier, Evidence<P, SP>>,
     unprovable_errors: BTreeMap<SP::Verifier, RemoteError>,
     missing_messages: BTreeMap<RoundId, BTreeSet<SP::Verifier>>,
@@ -34,8 +33,8 @@ where
     pub fn update(
         self,
         round_id: RoundId,
-        echo_broadcasts: BTreeMap<SP::Verifier, SignedMessage<SP::Signature, EchoBroadcast>>,
-        direct_messages: BTreeMap<SP::Verifier, SignedMessage<SP::Signature, DirectMessage>>,
+        echo_broadcasts: BTreeMap<SP::Verifier, SignedMessage<EchoBroadcast>>,
+        direct_messages: BTreeMap<SP::Verifier, SignedMessage<DirectMessage>>,
         provable_errors: BTreeMap<SP::Verifier, Evidence<P, SP>>,
         unprovable_errors: BTreeMap<SP::Verifier, RemoteError>,
         missing_messages: BTreeSet<SP::Verifier>,
@@ -101,7 +100,7 @@ where
         &self,
         round_id: RoundId,
         from: &SP::Verifier,
-    ) -> Result<SignedMessage<SP::Signature, EchoBroadcast>, LocalError> {
+    ) -> Result<SignedMessage<EchoBroadcast>, LocalError> {
         self.echo_broadcasts
             .get(&round_id)
             .ok_or_else(|| LocalError::new(format!("No echo broadcasts registered for {round_id:?}")))?
@@ -114,7 +113,7 @@ where
         &self,
         round_id: RoundId,
         from: &SP::Verifier,
-    ) -> Result<SignedMessage<SP::Signature, DirectMessage>, LocalError> {
+    ) -> Result<SignedMessage<DirectMessage>, LocalError> {
         self.direct_messages
             .get(&round_id)
             .ok_or_else(|| LocalError::new(format!("No direct messages registered for {round_id:?}")))?
@@ -127,11 +126,10 @@ where
         self.provable_errors.contains_key(from) || self.unprovable_errors.contains_key(from)
     }
 
-    #[allow(clippy::type_complexity)]
     pub fn echo_broadcasts(
         &self,
         round_id: RoundId,
-    ) -> Result<BTreeMap<SP::Verifier, SignedMessage<SP::Signature, EchoBroadcast>>, LocalError> {
+    ) -> Result<BTreeMap<SP::Verifier, SignedMessage<EchoBroadcast>>, LocalError> {
         self.echo_broadcasts
             .get(&round_id)
             .cloned()

--- a/manul/src/testing.rs
+++ b/manul/src/testing.rs
@@ -6,6 +6,6 @@ mod identity;
 mod macros;
 mod run_sync;
 
-pub use identity::{Hasher, Signature, Signer, Verifier};
+pub use identity::{Hasher, Signature, Signer, TestingSessionParams, Verifier};
 pub use macros::{round_override, RoundOverride, RoundWrapper};
 pub use run_sync::run_sync;

--- a/manul/src/testing/identity.rs
+++ b/manul/src/testing/identity.rs
@@ -2,6 +2,8 @@ use digest::generic_array::typenum;
 use rand_core::CryptoRngCore;
 use serde::{Deserialize, Serialize};
 
+use crate::session::SessionParameters;
+
 /// A simple signer for testing purposes.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 pub struct Signer(u8);
@@ -83,6 +85,17 @@ impl digest::FixedOutput for Hasher {
 
 impl digest::OutputSizeUser for Hasher {
     type OutputSize = typenum::U8;
+}
+
+/// An implementation of [`SessionParameters`] using the testing signer/verifier types.
+#[derive(Debug, Clone, Copy)]
+pub struct TestingSessionParams;
+
+impl SessionParameters for TestingSessionParams {
+    type Signer = Signer;
+    type Verifier = Verifier;
+    type Signature = Signature;
+    type Digest = Hasher;
 }
 
 #[cfg(test)]

--- a/manul/src/testing/run_sync.rs
+++ b/manul/src/testing/run_sync.rs
@@ -1,53 +1,41 @@
 use alloc::{collections::BTreeMap, vec::Vec};
-use core::fmt::Debug;
 
 use rand::Rng;
 use rand_core::CryptoRngCore;
-use serde::{Deserialize, Serialize};
-use signature::{DigestVerifier, Keypair, RandomizedDigestSigner};
+use signature::Keypair;
 use tracing::debug;
 
 use crate::{
     protocol::{FirstRound, Protocol},
     session::{
-        CanFinalize, LocalError, MessageBundle, RoundAccumulator, RoundOutcome, Session, SessionId, SessionReport,
+        CanFinalize, LocalError, MessageBundle, RoundAccumulator, RoundOutcome, Session, SessionId, SessionParameters,
+        SessionReport,
     },
 };
 
-enum State<P: Protocol, Signer, Verifier, S> {
+enum State<P: Protocol, SP: SessionParameters> {
     InProgress {
-        session: Session<P, Signer, Verifier, S>,
-        accum: RoundAccumulator<P, Verifier, S>,
+        session: Session<P, SP>,
+        accum: RoundAccumulator<P, SP>,
     },
-    Finished(SessionReport<P, Verifier, S>),
+    Finished(SessionReport<P, SP>),
 }
 
-struct Message<Verifier, S> {
-    from: Verifier,
-    to: Verifier,
-    message: MessageBundle<S>,
+struct Message<SP: SessionParameters> {
+    from: SP::Verifier,
+    to: SP::Verifier,
+    message: MessageBundle<SP>,
 }
 
 #[allow(clippy::type_complexity)]
-fn propagate<P, Signer, Verifier, S>(
+fn propagate<P, SP>(
     rng: &mut impl CryptoRngCore,
-    session: Session<P, Signer, Verifier, S>,
-    accum: RoundAccumulator<P, Verifier, S>,
-) -> Result<(State<P, Signer, Verifier, S>, Vec<Message<Verifier, S>>), LocalError>
+    session: Session<P, SP>,
+    accum: RoundAccumulator<P, SP>,
+) -> Result<(State<P, SP>, Vec<Message<SP>>), LocalError>
 where
-    P: Protocol + 'static,
-    Signer: RandomizedDigestSigner<P::Digest, S> + Keypair<VerifyingKey = Verifier>,
-    Verifier: Debug
-        + Clone
-        + Eq
-        + Ord
-        + DigestVerifier<P::Digest, S>
-        + 'static
-        + Serialize
-        + for<'de> Deserialize<'de>
-        + Send
-        + Sync,
-    S: Debug + Clone + Eq + 'static + Serialize + for<'de> Deserialize<'de> + Send + Sync,
+    P: 'static + Protocol,
+    SP: 'static + SessionParameters,
 {
     let mut messages = Vec::new();
 
@@ -101,24 +89,13 @@ where
 /// Execute sessions for multiple nodes concurrently, given the the inputs
 /// for the first round `R` and the signer for each node.
 #[allow(clippy::type_complexity)]
-pub fn run_sync<R, Signer, Verifier, S>(
+pub fn run_sync<R, SP>(
     rng: &mut impl CryptoRngCore,
-    inputs: Vec<(Signer, R::Inputs)>,
-) -> Result<BTreeMap<Verifier, SessionReport<R::Protocol, Verifier, S>>, LocalError>
+    inputs: Vec<(SP::Signer, R::Inputs)>,
+) -> Result<BTreeMap<SP::Verifier, SessionReport<R::Protocol, SP>>, LocalError>
 where
-    R: FirstRound<Verifier> + 'static,
-    Signer: RandomizedDigestSigner<<R::Protocol as Protocol>::Digest, S> + Keypair<VerifyingKey = Verifier>,
-    Verifier: Debug
-        + Clone
-        + Eq
-        + Ord
-        + DigestVerifier<<R::Protocol as Protocol>::Digest, S>
-        + 'static
-        + Serialize
-        + for<'de> Deserialize<'de>
-        + Send
-        + Sync,
-    S: Debug + Clone + Eq + 'static + Serialize + for<'de> Deserialize<'de> + Send + Sync,
+    R: 'static + FirstRound<SP::Verifier>,
+    SP: 'static + SessionParameters,
 {
     let session_id = SessionId::random(rng);
 
@@ -127,7 +104,7 @@ where
 
     for (signer, inputs) in inputs {
         let verifier = signer.verifying_key();
-        let session = Session::<R::Protocol, Signer, Verifier, S>::new::<R>(rng, session_id.clone(), signer, inputs)?;
+        let session = Session::<R::Protocol, SP>::new::<R>(rng, session_id.clone(), signer, inputs)?;
         let mut accum = session.make_accumulator();
 
         let destinations = session.message_destinations();

--- a/manul/src/testing/run_sync.rs
+++ b/manul/src/testing/run_sync.rs
@@ -24,7 +24,7 @@ enum State<P: Protocol, SP: SessionParameters> {
 struct Message<SP: SessionParameters> {
     from: SP::Verifier,
     to: SP::Verifier,
-    message: MessageBundle<SP>,
+    message: MessageBundle,
 }
 
 #[allow(clippy::type_complexity)]


### PR DESCRIPTION
This significantly reduces the generics noise in the session layer, and also seems logical from the API perspective: signing types are basically a parameter supplied by the user to the session level. So `Digest` should be a part of them too, and not an associated type of `Protocol`.

The second commit fixes #6. There is a very slight performance regression, about 2%, but I think it is worth it given the simplified API.

Also makes it much easier to implement #33 - so perhaps it should be redone after this goes in.  