### PR TITLE
Tie `SessionId` to `SessionParameters::Digest`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `MessageBundle` is not generic anymore. ([#36])
 - `ProcessedArtifact` is now also generic on `SessionParameters`. ([#37])
 - Added a `Test` prefix to `testing::Signer`/`Verifier`/`Signature`/`Hasher` and renamed `TestingSessionParams` to `TestSessionParams`. ([#40])
+- `SessionId::new()` renamed to `from_seed()`. ([#41])
+- `FirstRound::new()` takes a `&[u8]` instead of a `SessionId` object. ([#41])
 
 
 ### Added
@@ -22,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#36]: https://github.com/entropyxyz/manul/pull/36
 [#37]: https://github.com/entropyxyz/manul/pull/37
 [#40]: https://github.com/entropyxyz/manul/pull/40
+[#41]: https://github.com/entropyxyz/manul/pull/41
 
 
 ## [0.0.1] - 2024-10-12

--- a/examples/src/simple.rs
+++ b/examples/src/simple.rs
@@ -130,7 +130,7 @@ impl<Id: 'static + Debug + Clone + Ord + Send + Sync> FirstRound<Id> for Round1<
     type Inputs = Inputs<Id>;
     fn new(
         _rng: &mut impl CryptoRngCore,
-        _session_id: &SessionId,
+        _shared_randomness: &[u8],
         id: Id,
         inputs: Self::Inputs,
     ) -> Result<Self, LocalError> {

--- a/examples/src/simple_malicious.rs
+++ b/examples/src/simple_malicious.rs
@@ -2,9 +2,7 @@ use alloc::collections::{BTreeMap, BTreeSet};
 use core::fmt::Debug;
 
 use manul::{
-    protocol::{
-        Artifact, DirectMessage, FinalizeError, FinalizeOutcome, FirstRound, LocalError, Payload, Round, SessionId,
-    },
+    protocol::{Artifact, DirectMessage, FinalizeError, FinalizeOutcome, FirstRound, LocalError, Payload, Round},
     session::signature::Keypair,
     testing::{round_override, run_sync, RoundOverride, RoundWrapper, TestSessionParams, TestSigner, TestVerifier},
 };
@@ -46,11 +44,11 @@ impl<Id: 'static + Debug + Clone + Ord + Send + Sync> FirstRound<Id> for Malicio
     type Inputs = MaliciousInputs<Id>;
     fn new(
         rng: &mut impl CryptoRngCore,
-        session_id: &SessionId,
+        shared_randomness: &[u8],
         id: Id,
         inputs: Self::Inputs,
     ) -> Result<Self, LocalError> {
-        let round = Round1::new(rng, session_id, id, inputs.inputs)?;
+        let round = Round1::new(rng, shared_randomness, id, inputs.inputs)?;
         Ok(Self {
             round,
             behavior: inputs.behavior,

--- a/examples/tests/async_runner.rs
+++ b/examples/tests/async_runner.rs
@@ -249,7 +249,7 @@ async fn async_run() {
         .iter()
         .map(|signer| signer.verifying_key())
         .collect::<BTreeSet<_>>();
-    let session_id = SessionId::random(&mut OsRng);
+    let session_id = SessionId::random::<TestSessionParams>(&mut OsRng);
 
     // Create 4 `Session`s
     let sessions = signers

--- a/manul/benches/empty_rounds.rs
+++ b/manul/benches/empty_rounds.rs
@@ -9,7 +9,7 @@ use manul::{
         Artifact, DeserializationError, DirectMessage, EchoBroadcast, FinalizeError, FinalizeOutcome, FirstRound,
         LocalError, Payload, Protocol, ProtocolError, ProtocolValidationError, ReceiveError, Round, RoundId,
     },
-    session::{signature::Keypair, SessionId, SessionOutcome},
+    session::{signature::Keypair, SessionOutcome},
     testing::{run_sync, TestSessionParams, TestSigner, TestVerifier},
 };
 use rand_core::{CryptoRngCore, OsRng};
@@ -78,7 +78,7 @@ impl<Id: 'static + Debug + Clone + Ord + Send + Sync> FirstRound<Id> for EmptyRo
     type Inputs = Inputs<Id>;
     fn new(
         _rng: &mut impl CryptoRngCore,
-        _session_id: &SessionId,
+        _shared_randomness: &[u8],
         _id: Id,
         inputs: Self::Inputs,
     ) -> Result<Self, LocalError> {

--- a/manul/src/protocol.rs
+++ b/manul/src/protocol.rs
@@ -15,7 +15,6 @@ mod errors;
 mod object_safe;
 mod round;
 
-pub use crate::session::SessionId;
 pub use errors::{
     DeserializationError, DirectMessageError, EchoBroadcastError, FinalizeError, LocalError, MessageValidationError,
     ProtocolValidationError, ReceiveError, RemoteError,

--- a/manul/src/protocol/round.rs
+++ b/manul/src/protocol/round.rs
@@ -17,7 +17,6 @@ use super::{
     },
     object_safe::{ObjectSafeRound, ObjectSafeRoundWrapper},
 };
-use crate::session::SessionId;
 
 /// Possible successful outcomes of [`Round::finalize`].
 #[derive(Debug)]
@@ -347,7 +346,7 @@ pub trait FirstRound<Id: 'static>: Round<Id> + Sized {
     /// `id` is the ID of this node.
     fn new(
         rng: &mut impl CryptoRngCore,
-        session_id: &SessionId,
+        shared_randomness: &[u8],
         id: Id,
         inputs: Self::Inputs,
     ) -> Result<Self, LocalError>;

--- a/manul/src/testing/run_sync.rs
+++ b/manul/src/testing/run_sync.rs
@@ -99,7 +99,7 @@ where
     R: 'static + FirstRound<SP::Verifier>,
     SP: 'static + SessionParameters + Debug,
 {
-    let session_id = SessionId::random(rng);
+    let session_id = SessionId::random::<SP>(rng);
 
     let mut messages = Vec::new();
     let mut states = BTreeMap::new();


### PR DESCRIPTION
Fixes #9
Affects #25 

- `SessionId` now hashes the incoming randomness using `SessionParameters::Digest` and keeps that hash. `SessionId::new()` renamed to `from_seed()`.
- `FirstRound::new` takes an `&[u8]` instead of a `SessionId` to reduce the coupling between layers.

This PR may possibly include making `SessionId` generic over `SessionParameters` and using `digest::Output<SP::Digest>` (which is a stack array) instead of `Box<[u8]>`, but that actually affects a lot of types (messages, evidences), so I am not sure if it's worth it. 