### PR TITLE
Handle cases where a node sent or not sent a part of the message unexpectedly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,11 +13,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added a `Test` prefix to `testing::Signer`/`Verifier`/`Signature`/`Hasher` and renamed `TestingSessionParams` to `TestSessionParams`. ([#40])
 - `SessionId::new()` renamed to `from_seed()`. ([#41])
 - `FirstRound::new()` takes a `&[u8]` instead of a `SessionId` object. ([#41])
+- The signatures of `Round::make_echo_broadcast()`, `Round::make_direct_message()`, and `Round::receive_message()`, take messages without `Option`s. ([#46])
+- `Round::make_direct_message_with_artifact()` is the method returning an artifact now; `Round::make_direct_message()` is a shortcut for cases where no artifact is returned. ([#46])
+- `Artifact::empty()` removed, the user should return `None` instead. ([#46])
 
 
 ### Added
 
 - `SerializableMap` wrapper for `BTreeMap` supporting more formats and providing some safety features. (#[32])
+- `DirectMessage::assert_is_none()` and `verify_is_some()`, same for `EchoBroadcast`. Users can now check that a part of the round message (echo or direct) is `None` as expected, and make a verifiable evidence if it is not. ([#46])
 
 
 [#32]: https://github.com/entropyxyz/manul/pull/32
@@ -25,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#37]: https://github.com/entropyxyz/manul/pull/37
 [#40]: https://github.com/entropyxyz/manul/pull/40
 [#41]: https://github.com/entropyxyz/manul/pull/41
+[#46]: https://github.com/entropyxyz/manul/pull/46
 
 
 ## [0.0.1] - 2024-10-12

--- a/examples/src/simple_malicious.rs
+++ b/examples/src/simple_malicious.rs
@@ -57,21 +57,17 @@ impl<Id: 'static + Debug + Clone + Ord + Send + Sync> FirstRound<Id> for Malicio
 }
 
 impl<Id: 'static + Debug + Clone + Ord + Send + Sync> RoundOverride<Id> for MaliciousRound1<Id> {
-    fn make_direct_message(
-        &self,
-        rng: &mut impl CryptoRngCore,
-        destination: &Id,
-    ) -> Result<(DirectMessage, Artifact), LocalError> {
+    fn make_direct_message(&self, rng: &mut impl CryptoRngCore, destination: &Id) -> Result<DirectMessage, LocalError> {
         if matches!(self.behavior, Behavior::SerializedGarbage) {
             let dm = DirectMessage::new::<<Self::InnerRound as Round<Id>>::Protocol, _>(&[99u8]).unwrap();
-            Ok((dm, Artifact::empty()))
+            Ok(dm)
         } else if matches!(self.behavior, Behavior::AttributableFailure) {
             let message = Round1Message {
                 my_position: self.round.context.ids_to_positions[&self.round.context.id],
                 your_position: self.round.context.ids_to_positions[&self.round.context.id],
             };
             let dm = DirectMessage::new::<<Self::InnerRound as Round<Id>>::Protocol, _>(&message)?;
-            Ok((dm, Artifact::empty()))
+            Ok(dm)
         } else {
             self.inner_round_ref().make_direct_message(rng, destination)
         }
@@ -121,18 +117,14 @@ impl<Id: 'static + Debug + Clone + Ord + Send + Sync> RoundWrapper<Id> for Malic
 }
 
 impl<Id: 'static + Debug + Clone + Ord + Send + Sync> RoundOverride<Id> for MaliciousRound2<Id> {
-    fn make_direct_message(
-        &self,
-        rng: &mut impl CryptoRngCore,
-        destination: &Id,
-    ) -> Result<(DirectMessage, Artifact), LocalError> {
+    fn make_direct_message(&self, rng: &mut impl CryptoRngCore, destination: &Id) -> Result<DirectMessage, LocalError> {
         if matches!(self.behavior, Behavior::AttributableFailureRound2) {
             let message = Round2Message {
                 my_position: self.round.context.ids_to_positions[&self.round.context.id],
                 your_position: self.round.context.ids_to_positions[&self.round.context.id],
             };
             let dm = DirectMessage::new::<<Self::InnerRound as Round<Id>>::Protocol, _>(&message)?;
-            Ok((dm, Artifact::empty()))
+            Ok(dm)
         } else {
             self.inner_round_ref().make_direct_message(rng, destination)
         }

--- a/manul/src/protocol.rs
+++ b/manul/src/protocol.rs
@@ -12,6 +12,7 @@ For more details, see the documentation of the mentioned traits.
 */
 
 mod errors;
+mod message;
 mod object_safe;
 mod round;
 
@@ -19,9 +20,9 @@ pub use errors::{
     DeserializationError, DirectMessageError, EchoBroadcastError, FinalizeError, LocalError, MessageValidationError,
     ProtocolValidationError, ReceiveError, RemoteError,
 };
+pub use message::{DirectMessage, EchoBroadcast};
 pub use round::{
-    AnotherRound, Artifact, DirectMessage, EchoBroadcast, FinalizeOutcome, FirstRound, Payload, Protocol,
-    ProtocolError, Round, RoundId,
+    AnotherRound, Artifact, FinalizeOutcome, FirstRound, Payload, Protocol, ProtocolError, Round, RoundId,
 };
 
 pub(crate) use errors::ReceiveErrorType;

--- a/manul/src/protocol/errors.rs
+++ b/manul/src/protocol/errors.rs
@@ -193,7 +193,13 @@ impl From<LocalError> for ProtocolValidationError {
 pub struct DirectMessageError(DeserializationError);
 
 impl DirectMessageError {
-    pub(crate) fn new(error: DeserializationError) -> Self {
+    pub(crate) fn new(message: impl Into<String>) -> Self {
+        Self(DeserializationError::new(message))
+    }
+}
+
+impl From<DeserializationError> for DirectMessageError {
+    fn from(error: DeserializationError) -> Self {
         Self(error)
     }
 }
@@ -204,7 +210,13 @@ impl DirectMessageError {
 pub struct EchoBroadcastError(DeserializationError);
 
 impl EchoBroadcastError {
-    pub(crate) fn new(error: DeserializationError) -> Self {
+    pub(crate) fn new(message: impl Into<String>) -> Self {
+        Self(DeserializationError::new(message))
+    }
+}
+
+impl From<DeserializationError> for EchoBroadcastError {
+    fn from(error: DeserializationError) -> Self {
         Self(error)
     }
 }

--- a/manul/src/protocol/message.rs
+++ b/manul/src/protocol/message.rs
@@ -1,0 +1,149 @@
+use alloc::boxed::Box;
+
+use serde::{Deserialize, Serialize};
+use serde_encoded_bytes::{Base64, SliceLike};
+
+use super::{
+    errors::{DirectMessageError, EchoBroadcastError, LocalError, MessageValidationError},
+    round::Protocol,
+};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct DirectMessagePayload(#[serde(with = "SliceLike::<Base64>")] Box<[u8]>);
+
+/// A serialized direct message.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DirectMessage(Option<DirectMessagePayload>);
+
+impl DirectMessage {
+    /// Creates an empty message.
+    ///
+    /// Use in case the round does not send a message of this type.
+    pub fn none() -> Self {
+        Self(None)
+    }
+
+    /// Creates a new serialized direct message.
+    pub fn new<P: Protocol, T: Serialize>(message: T) -> Result<Self, LocalError> {
+        Ok(Self(Some(DirectMessagePayload(P::serialize(message)?))))
+    }
+
+    /// Returns `true` if this is an empty message.
+    pub(crate) fn is_none(&self) -> bool {
+        self.0.is_none()
+    }
+
+    /// Returns `Ok(())` if the message is indeed an empty message.
+    pub fn assert_is_none(&self) -> Result<(), DirectMessageError> {
+        if self.is_none() {
+            Ok(())
+        } else {
+            Err(DirectMessageError::new("The expected direct message is missing"))
+        }
+    }
+
+    /// Returns `Ok(())` if the message cannot be deserialized into `T`.
+    ///
+    /// This is intended to be used in the implementations of [`Protocol::verify_direct_message_is_invalid`].
+    pub fn verify_is_not<P: Protocol, T: for<'de> Deserialize<'de>>(&self) -> Result<(), MessageValidationError> {
+        if self.deserialize::<P, T>().is_err() {
+            Ok(())
+        } else {
+            Err(MessageValidationError::InvalidEvidence(
+                "Message deserialized successfully".into(),
+            ))
+        }
+    }
+
+    /// Returns `Ok(())` if the message contains a payload.
+    ///
+    /// This is intended to be used in the implementations of [`Protocol::verify_direct_message_is_invalid`].
+    pub fn verify_is_some(&self) -> Result<(), MessageValidationError> {
+        if self.0.is_some() {
+            Ok(())
+        } else {
+            Err(MessageValidationError::InvalidEvidence(
+                "Message's payload is None".into(),
+            ))
+        }
+    }
+
+    /// Deserializes the direct message.
+    pub fn deserialize<P: Protocol, T: for<'de> Deserialize<'de>>(&self) -> Result<T, DirectMessageError> {
+        let payload = self
+            .0
+            .as_ref()
+            .ok_or_else(|| DirectMessageError::new("The direct message is missing in the payload"))?;
+        P::deserialize(&payload.0).map_err(DirectMessageError::from)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct EchoBroadcastPayload(#[serde(with = "SliceLike::<Base64>")] Box<[u8]>);
+
+/// A serialized echo broadcast.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct EchoBroadcast(Option<EchoBroadcastPayload>);
+
+impl EchoBroadcast {
+    /// Creates an empty message.
+    ///
+    /// Use in case the round does not send a message of this type.
+    pub fn none() -> Self {
+        Self(None)
+    }
+
+    /// Creates a new serialized echo broadcast.
+    pub fn new<P: Protocol, T: Serialize>(message: T) -> Result<Self, LocalError> {
+        Ok(Self(Some(EchoBroadcastPayload(P::serialize(message)?))))
+    }
+
+    /// Returns `true` if this is an empty message.
+    pub(crate) fn is_none(&self) -> bool {
+        self.0.is_none()
+    }
+
+    /// Returns `Ok(())` if the message is indeed an empty message.
+    pub fn assert_is_none(&self) -> Result<(), EchoBroadcastError> {
+        if self.is_none() {
+            Ok(())
+        } else {
+            Err(EchoBroadcastError::new("The expected echo broadcast is missing"))
+        }
+    }
+
+    /// Returns `Ok(())` if the message cannot be deserialized into `T`.
+    ///
+    /// This is intended to be used in the implementations of [`Protocol::verify_direct_message_is_invalid`].
+    pub fn verify_is_not<P: Protocol, T: for<'de> Deserialize<'de>>(&self) -> Result<(), MessageValidationError> {
+        if self.deserialize::<P, T>().is_err() {
+            Ok(())
+        } else {
+            Err(MessageValidationError::InvalidEvidence(
+                "Message deserialized successfully".into(),
+            ))
+        }
+    }
+
+    /// Returns `Ok(())` if the message contains a payload.
+    ///
+    /// This is intended to be used in the implementations of [`Protocol::verify_direct_message_is_invalid`].
+    pub fn verify_is_some(&self) -> Result<(), MessageValidationError> {
+        if self.0.is_some() {
+            Ok(())
+        } else {
+            Err(MessageValidationError::InvalidEvidence(
+                "Message's payload is None".into(),
+            ))
+        }
+    }
+
+    /// Deserializes the echo broadcast.
+    pub fn deserialize<P: Protocol, T: for<'de> Deserialize<'de>>(&self) -> Result<T, EchoBroadcastError> {
+        let payload = self
+            .0
+            .as_ref()
+            .ok_or_else(|| EchoBroadcastError::new("The direct message is missing in the payload"))?;
+        P::deserialize(&payload.0).map_err(EchoBroadcastError::from)
+    }
+}

--- a/manul/src/session/echo.rs
+++ b/manul/src/session/echo.rs
@@ -106,7 +106,7 @@ where
         &self,
         _rng: &mut impl CryptoRngCore,
         destination: &SP::Verifier,
-    ) -> Result<(DirectMessage, Artifact), LocalError> {
+    ) -> Result<DirectMessage, LocalError> {
         debug!("{:?}: making echo round message for {:?}", self.verifier, destination);
 
         // Don't send our own message the second time
@@ -122,7 +122,7 @@ where
             echo_broadcasts: echo_broadcasts.into(),
         };
         let dm = DirectMessage::new::<P, _>(&message)?;
-        Ok((dm, Artifact::empty()))
+        Ok(dm)
     }
 
     fn expecting_messages_from(&self) -> &BTreeSet<SP::Verifier> {
@@ -133,10 +133,12 @@ where
         &self,
         _rng: &mut impl CryptoRngCore,
         from: &SP::Verifier,
-        _echo_broadcast: Option<EchoBroadcast>,
+        echo_broadcast: EchoBroadcast,
         direct_message: DirectMessage,
     ) -> Result<Payload, ReceiveError<SP::Verifier, Self::Protocol>> {
         debug!("{:?}: received an echo message from {:?}", self.verifier, from);
+
+        echo_broadcast.assert_is_none()?;
 
         let message = direct_message.deserialize::<P, EchoRoundMessage<SP>>()?;
 

--- a/manul/src/session/evidence.rs
+++ b/manul/src/session/evidence.rs
@@ -155,7 +155,7 @@ where
                     .map_err(|error| {
                         LocalError::new(format!("Failed to deserialize the given direct message: {:?}", error))
                     })?;
-                let echoed_to_us = deserialized.echo_messages.get(&from).ok_or_else(|| {
+                let echoed_to_us = deserialized.echo_broadcasts.get(&from).ok_or_else(|| {
                     LocalError::new(format!(
                         "The echo message from {from:?} is missing from the echo packet"
                     ))
@@ -248,7 +248,7 @@ where
         let verified = self.direct_message.clone().verify::<P, SP>(verifier)?;
         let deserialized = verified.payload().deserialize::<P, EchoRoundMessage<SP>>()?;
         let invalid_echo = deserialized
-            .echo_messages
+            .echo_broadcasts
             .get(&self.invalid_echo_sender)
             .ok_or_else(|| {
                 EvidenceError::InvalidEvidence(format!(
@@ -419,7 +419,7 @@ where
             let echo_set = DirectMessage::deserialize::<P, EchoRoundMessage<SP>>(verified_combined_echo.payload())?;
 
             let mut verified_echo_set = Vec::new();
-            for (other_verifier, echo_broadcast) in echo_set.echo_messages.iter() {
+            for (other_verifier, echo_broadcast) in echo_set.echo_broadcasts.iter() {
                 let verified_echo_broadcast = echo_broadcast.clone().verify::<P, SP>(other_verifier)?;
                 let metadata = verified_echo_broadcast.metadata();
                 if metadata.session_id() != session_id || metadata.round_id() != *round_id {

--- a/manul/src/session/session.rs
+++ b/manul/src/session/session.rs
@@ -107,7 +107,7 @@ pub struct Session<P: Protocol, SP: SessionParameters> {
     verifier: SP::Verifier,
     round: Box<dyn ObjectSafeRound<SP::Verifier, Protocol = P>>,
     message_destinations: BTreeSet<SP::Verifier>,
-    echo_broadcast: Option<SignedMessage<EchoBroadcast>>,
+    echo_broadcast: SignedMessage<EchoBroadcast>,
     possible_next_rounds: BTreeSet<RoundId>,
     transcript: Transcript<P, SP>,
 }
@@ -159,14 +159,11 @@ where
         transcript: Transcript<P, SP>,
     ) -> Result<Self, LocalError> {
         let verifier = signer.verifying_key();
-        let echo_broadcast = round
-            .make_echo_broadcast(rng)
-            .transpose()?
-            .map(|echo| SignedMessage::new::<P, SP>(rng, &signer, &session_id, round.id(), echo))
-            .transpose()?;
+        let echo = round.make_echo_broadcast(rng)?;
+        let echo_broadcast = SignedMessage::new::<P, SP>(rng, &signer, &session_id, round.id(), echo)?;
         let message_destinations = round.message_destinations().clone();
 
-        let possible_next_rounds = if echo_broadcast.is_none() {
+        let possible_next_rounds = if echo_broadcast.payload().is_none() {
             round.possible_next_rounds()
         } else {
             BTreeSet::from([round.id().echo()])
@@ -207,7 +204,7 @@ where
         rng: &mut impl CryptoRngCore,
         destination: &SP::Verifier,
     ) -> Result<(MessageBundle, ProcessedArtifact<SP>), LocalError> {
-        let (direct_message, artifact) = self.round.make_direct_message(rng, destination)?;
+        let (direct_message, artifact) = self.round.make_direct_message_with_artifact(rng, destination)?;
 
         let bundle = MessageBundle::new::<P, SP>(
             rng,
@@ -359,7 +356,7 @@ where
         let processed = self.round.receive_message(
             rng,
             message.from(),
-            message.echo_broadcast().cloned(),
+            message.echo_broadcast().clone(),
             message.direct_message().clone(),
         );
         // We could filter out and return a possible `LocalError` at this stage,
@@ -413,10 +410,12 @@ where
             accum.still_have_not_sent_messages,
         )?;
 
-        if let Some(echo_broadcast) = self.echo_broadcast {
+        let echo_round_needed = !self.echo_broadcast.payload().is_none();
+
+        if echo_round_needed {
             let round = Box::new(ObjectSafeRoundWrapper::new(EchoRound::<P, SP>::new(
                 verifier,
-                echo_broadcast,
+                self.echo_broadcast,
                 transcript.echo_broadcasts(round_id)?,
                 self.round,
                 accum.payloads,
@@ -586,11 +585,12 @@ where
     }
 
     fn add_artifact(&mut self, processed: ProcessedArtifact<SP>) -> Result<(), LocalError> {
-        if self
-            .artifacts
-            .insert(processed.destination.clone(), processed.artifact)
-            .is_some()
-        {
+        let artifact = match processed.artifact {
+            Some(artifact) => artifact,
+            None => return Ok(()),
+        };
+
+        if self.artifacts.insert(processed.destination.clone(), artifact).is_some() {
             return Err(LocalError::new(format!(
                 "Artifact for destination {:?} has already been recorded",
                 processed.destination
@@ -622,11 +622,14 @@ where
 
         let error = match processed.processed {
             Ok(payload) => {
+                // Note: only inserting the messages if they actually have a payload
                 let (echo_broadcast, direct_message) = processed.message.into_parts();
-                if let Some(echo) = echo_broadcast {
-                    self.echo_broadcasts.insert(from.clone(), echo);
+                if !echo_broadcast.payload().is_none() {
+                    self.echo_broadcasts.insert(from.clone(), echo_broadcast);
                 }
-                self.direct_messages.insert(from.clone(), direct_message);
+                if !direct_message.payload().is_none() {
+                    self.direct_messages.insert(from.clone(), direct_message);
+                }
                 self.payloads.insert(from.clone(), payload);
                 return Ok(());
             }
@@ -641,8 +644,6 @@ where
             }
             ReceiveErrorType::InvalidEchoBroadcast(error) => {
                 let (echo_broadcast, _direct_message) = processed.message.into_parts();
-                let echo_broadcast =
-                    echo_broadcast.ok_or_else(|| LocalError::new("Expected a non-None echo broadcast"))?;
                 let evidence = Evidence::new_invalid_echo_broadcast(&from, echo_broadcast, error);
                 self.register_provable_error(&from, evidence)
             }
@@ -681,7 +682,7 @@ where
 #[derive(Debug)]
 pub struct ProcessedArtifact<SP: SessionParameters> {
     destination: SP::Verifier,
-    artifact: Artifact,
+    artifact: Option<Artifact>,
 }
 
 #[derive(Debug)]
@@ -735,7 +736,7 @@ mod tests {
         impl ProtocolError for DummyProtocolError {
             fn verify_messages_constitute_error(
                 &self,
-                _echo_broadcast: &Option<EchoBroadcast>,
+                _echo_broadcast: &EchoBroadcast,
                 _direct_message: &DirectMessage,
                 _echo_broadcasts: &BTreeMap<RoundId, EchoBroadcast>,
                 _direct_messages: &BTreeMap<RoundId, DirectMessage>,

--- a/manul/src/testing.rs
+++ b/manul/src/testing.rs
@@ -5,10 +5,11 @@ When testing round based protocols it can be complicated to "inject" the proper 
 process, e.g. to emulate a malicious participant. This module provides facilities to make this
 easier, by providing a [`RoundOverride`] type along with a [`round_override`] macro.
 
-The [`TestSessionParams`] provides an implementation of the [`SessionParameters`](crate::session::SessionParameters) trait,
+The [`TestSessionParams`] provides an implementation of the
+[`SessionParameters`](crate::session::SessionParameters) trait,
 which in turn is used to setup [`Session`](crate::session::Session)s to drive the protocol.
 
-The [`run_sync`] method is helpful to execute a protocol synchronously and collect the outcomes.
+The [`run_sync()`] method is helpful to execute a protocol synchronously and collect the outcomes.
 */
 
 mod identity;


### PR DESCRIPTION
Fixes #23

The gist of the changes is that now even if a node does not send, say, a direct message, it still signs a `None` value with the corresponding metadata and sends it off in a bundle with the rest of the parts. This way the receiver can assert that the direct part or the echo part should be none, and register a provable error if they aren't. 

Of course the node could just not send the corresponding part at all (equivalent to sending any other malformed or mal-signed message), but as #39 suggests, we're mostly protecting against nodes with obsolete software, not actively malicious ones. 

Changes:
- Changed the signatures of `Round::make_echo_broadcast()`, `Round::make_direct_message()`, `Round::receive_message()` removing `Option`s there.
- Added `Round::make_direct_message_with_artifact()`; `Round::make_direct_message()` would be the one most used because most rounds in Synedrion don't actually create an artifact. 
- `Artifact::empty()` removed, since now we can just return `None`.

Outstanding questions:
- We do not need to keep signed empty messages in the transcript, but there is currently no type system assertion for that. Perhaps we don't need one, since the payload being `None` leads to the same outcome as a deserialization error on a `Some` payload, so `DirectMessage::deserialize()` just returns a `DirectMessageError` in this case as well, same for the echo broadcast. 
- The fallback from `make_direct_message_with_artifact()` to `make_direct_message()` is a little tricky in `RoundOverride`; if the round defines the former, but we override the latter, the override won't be effective. Not sure how to handle that; I really want to keep the artifact-creating method separate since it's not used all that much.
- Should we also allow returning `None` for an empty `Payload`?