### PR TITLE
Add support for simple broadcasts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Round::make_direct_message_with_artifact()` is the method returning an artifact now; `Round::make_direct_message()` is a shortcut for cases where no artifact is returned. ([#46])
 - `Artifact::empty()` removed, the user should return `None` instead. ([#46])
 - `EchoBroadcast` and `DirectMessage` now use `ProtocolMessagePart` trait for their methods. ([#47])
+- Added normal broadcasts support in addition to echo ones; signatures of `Round` methods changed accordingly; added `Round::make_normal_broadcast()`. ([#47])
 
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The signatures of `Round::make_echo_broadcast()`, `Round::make_direct_message()`, and `Round::receive_message()`, take messages without `Option`s. ([#46])
 - `Round::make_direct_message_with_artifact()` is the method returning an artifact now; `Round::make_direct_message()` is a shortcut for cases where no artifact is returned. ([#46])
 - `Artifact::empty()` removed, the user should return `None` instead. ([#46])
+- `EchoBroadcast` and `DirectMessage` now use `ProtocolMessagePart` trait for their methods. ([#47])
 
 
 ### Added
@@ -30,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#40]: https://github.com/entropyxyz/manul/pull/40
 [#41]: https://github.com/entropyxyz/manul/pull/41
 [#46]: https://github.com/entropyxyz/manul/pull/46
+[#47]: https://github.com/entropyxyz/manul/pull/47
 
 
 ## [0.0.1] - 2024-10-12

--- a/examples/src/simple_malicious.rs
+++ b/examples/src/simple_malicious.rs
@@ -2,7 +2,10 @@ use alloc::collections::{BTreeMap, BTreeSet};
 use core::fmt::Debug;
 
 use manul::{
-    protocol::{Artifact, DirectMessage, FinalizeError, FinalizeOutcome, FirstRound, LocalError, Payload, Round},
+    protocol::{
+        Artifact, DirectMessage, FinalizeError, FinalizeOutcome, FirstRound, LocalError, Payload, ProtocolMessagePart,
+        Round,
+    },
     session::signature::Keypair,
     testing::{round_override, run_sync, RoundOverride, RoundWrapper, TestSessionParams, TestSigner, TestVerifier},
 };

--- a/manul/benches/empty_rounds.rs
+++ b/manul/benches/empty_rounds.rs
@@ -7,8 +7,8 @@ use criterion::{criterion_group, criterion_main, Criterion};
 use manul::{
     protocol::{
         Artifact, DeserializationError, DirectMessage, EchoBroadcast, FinalizeError, FinalizeOutcome, FirstRound,
-        LocalError, Payload, Protocol, ProtocolError, ProtocolMessagePart, ProtocolValidationError, ReceiveError,
-        Round, RoundId,
+        LocalError, NormalBroadcast, Payload, Protocol, ProtocolError, ProtocolMessagePart, ProtocolValidationError,
+        ReceiveError, Round, RoundId,
     },
     session::{signature::Keypair, SessionOutcome},
     testing::{run_sync, TestSessionParams, TestSigner, TestVerifier},
@@ -26,8 +26,10 @@ impl ProtocolError for EmptyProtocolError {
     fn verify_messages_constitute_error(
         &self,
         _echo_broadcast: &EchoBroadcast,
+        _normal_broadcast: &NormalBroadcast,
         _direct_message: &DirectMessage,
         _echo_broadcasts: &BTreeMap<RoundId, EchoBroadcast>,
+        _normal_broadcasts: &BTreeMap<RoundId, NormalBroadcast>,
         _direct_messages: &BTreeMap<RoundId, DirectMessage>,
         _combined_echos: &BTreeMap<RoundId, Vec<EchoBroadcast>>,
     ) -> Result<(), ProtocolValidationError> {
@@ -132,6 +134,7 @@ impl<Id: 'static + Debug + Clone + Ord + Send + Sync> Round<Id> for EmptyRound<I
         _rng: &mut impl CryptoRngCore,
         _from: &Id,
         echo_broadcast: EchoBroadcast,
+        normal_broadcast: NormalBroadcast,
         direct_message: DirectMessage,
     ) -> Result<Payload, ReceiveError<Id, Self::Protocol>> {
         if self.inputs.echo {
@@ -139,6 +142,7 @@ impl<Id: 'static + Debug + Clone + Ord + Send + Sync> Round<Id> for EmptyRound<I
         } else {
             echo_broadcast.assert_is_none()?;
         }
+        normal_broadcast.assert_is_none()?;
         let _direct_message = direct_message.deserialize::<EmptyProtocol, Round1DirectMessage>()?;
         Ok(Payload::new(Round1Payload))
     }

--- a/manul/benches/empty_rounds.rs
+++ b/manul/benches/empty_rounds.rs
@@ -7,7 +7,8 @@ use criterion::{criterion_group, criterion_main, Criterion};
 use manul::{
     protocol::{
         Artifact, DeserializationError, DirectMessage, EchoBroadcast, FinalizeError, FinalizeOutcome, FirstRound,
-        LocalError, Payload, Protocol, ProtocolError, ProtocolValidationError, ReceiveError, Round, RoundId,
+        LocalError, Payload, Protocol, ProtocolError, ProtocolMessagePart, ProtocolValidationError, ReceiveError,
+        Round, RoundId,
     },
     session::{signature::Keypair, SessionOutcome},
     testing::{run_sync, TestSessionParams, TestSigner, TestVerifier},

--- a/manul/src/protocol.rs
+++ b/manul/src/protocol.rs
@@ -18,9 +18,9 @@ mod round;
 
 pub use errors::{
     DeserializationError, DirectMessageError, EchoBroadcastError, FinalizeError, LocalError, MessageValidationError,
-    ProtocolValidationError, ReceiveError, RemoteError,
+    NormalBroadcastError, ProtocolValidationError, ReceiveError, RemoteError,
 };
-pub use message::{DirectMessage, EchoBroadcast, ProtocolMessagePart};
+pub use message::{DirectMessage, EchoBroadcast, NormalBroadcast, ProtocolMessagePart};
 pub use round::{
     AnotherRound, Artifact, FinalizeOutcome, FirstRound, Payload, Protocol, ProtocolError, Round, RoundId,
 };

--- a/manul/src/protocol.rs
+++ b/manul/src/protocol.rs
@@ -20,7 +20,7 @@ pub use errors::{
     DeserializationError, DirectMessageError, EchoBroadcastError, FinalizeError, LocalError, MessageValidationError,
     ProtocolValidationError, ReceiveError, RemoteError,
 };
-pub use message::{DirectMessage, EchoBroadcast};
+pub use message::{DirectMessage, EchoBroadcast, ProtocolMessagePart};
 pub use round::{
     AnotherRound, Artifact, FinalizeOutcome, FirstRound, Payload, Protocol, ProtocolError, Round, RoundId,
 };

--- a/manul/src/protocol/errors.rs
+++ b/manul/src/protocol/errors.rs
@@ -40,6 +40,8 @@ pub(crate) enum ReceiveErrorType<Id, P: Protocol> {
     InvalidDirectMessage(DirectMessageError),
     /// The given echo broadcast cannot be deserialized.
     InvalidEchoBroadcast(EchoBroadcastError),
+    /// The given normal broadcast cannot be deserialized.
+    InvalidNormalBroadcast(NormalBroadcastError),
     /// A provable error occurred.
     Protocol(P::ProtocolError),
     /// An unprovable error occurred.
@@ -110,6 +112,15 @@ where
 {
     fn from(error: EchoBroadcastError) -> Self {
         Self(ReceiveErrorType::InvalidEchoBroadcast(error))
+    }
+}
+
+impl<Id, P> From<NormalBroadcastError> for ReceiveError<Id, P>
+where
+    P: Protocol,
+{
+    fn from(error: NormalBroadcastError) -> Self {
+        Self(ReceiveErrorType::InvalidNormalBroadcast(error))
     }
 }
 
@@ -204,6 +215,17 @@ impl From<String> for DirectMessageError {
 pub struct EchoBroadcastError(String);
 
 impl From<String> for EchoBroadcastError {
+    fn from(message: String) -> Self {
+        Self(message)
+    }
+}
+
+/// An error during deserialization of a normal broadcast.
+#[derive(displaydoc::Display, Debug, Clone)]
+#[displaydoc("Normal broadcast error: {0}")]
+pub struct NormalBroadcastError(String);
+
+impl From<String> for NormalBroadcastError {
     fn from(message: String) -> Self {
         Self(message)
     }

--- a/manul/src/protocol/errors.rs
+++ b/manul/src/protocol/errors.rs
@@ -190,33 +190,21 @@ impl From<LocalError> for ProtocolValidationError {
 /// An error during deserialization of a direct message.
 #[derive(displaydoc::Display, Debug, Clone)]
 #[displaydoc("Direct message error: {0}")]
-pub struct DirectMessageError(DeserializationError);
+pub struct DirectMessageError(String);
 
-impl DirectMessageError {
-    pub(crate) fn new(message: impl Into<String>) -> Self {
-        Self(DeserializationError::new(message))
-    }
-}
-
-impl From<DeserializationError> for DirectMessageError {
-    fn from(error: DeserializationError) -> Self {
-        Self(error)
+impl From<String> for DirectMessageError {
+    fn from(message: String) -> Self {
+        Self(message)
     }
 }
 
 /// An error during deserialization of an echo broadcast.
 #[derive(displaydoc::Display, Debug, Clone)]
 #[displaydoc("Echo broadcast error: {0}")]
-pub struct EchoBroadcastError(DeserializationError);
+pub struct EchoBroadcastError(String);
 
-impl EchoBroadcastError {
-    pub(crate) fn new(message: impl Into<String>) -> Self {
-        Self(DeserializationError::new(message))
-    }
-}
-
-impl From<DeserializationError> for EchoBroadcastError {
-    fn from(error: DeserializationError) -> Self {
-        Self(error)
+impl From<String> for EchoBroadcastError {
+    fn from(message: String) -> Self {
+        Self(message)
     }
 }

--- a/manul/src/protocol/message.rs
+++ b/manul/src/protocol/message.rs
@@ -1,149 +1,139 @@
-use alloc::boxed::Box;
+use alloc::string::{String, ToString};
 
 use serde::{Deserialize, Serialize};
-use serde_encoded_bytes::{Base64, SliceLike};
 
 use super::{
     errors::{DirectMessageError, EchoBroadcastError, LocalError, MessageValidationError},
     round::Protocol,
 };
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub(crate) struct DirectMessagePayload(#[serde(with = "SliceLike::<Base64>")] Box<[u8]>);
+mod private {
+    use alloc::boxed::Box;
+    use serde::{Deserialize, Serialize};
+    use serde_encoded_bytes::{Base64, SliceLike};
 
-/// A serialized direct message.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct DirectMessage(Option<DirectMessagePayload>);
+    #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+    pub struct MessagePayload(#[serde(with = "SliceLike::<Base64>")] pub Box<[u8]>);
 
-impl DirectMessage {
-    /// Creates an empty message.
-    ///
-    /// Use in case the round does not send a message of this type.
-    pub fn none() -> Self {
-        Self(None)
-    }
-
-    /// Creates a new serialized direct message.
-    pub fn new<P: Protocol, T: Serialize>(message: T) -> Result<Self, LocalError> {
-        Ok(Self(Some(DirectMessagePayload(P::serialize(message)?))))
-    }
-
-    /// Returns `true` if this is an empty message.
-    pub(crate) fn is_none(&self) -> bool {
-        self.0.is_none()
-    }
-
-    /// Returns `Ok(())` if the message is indeed an empty message.
-    pub fn assert_is_none(&self) -> Result<(), DirectMessageError> {
-        if self.is_none() {
-            Ok(())
-        } else {
-            Err(DirectMessageError::new("The expected direct message is missing"))
-        }
-    }
-
-    /// Returns `Ok(())` if the message cannot be deserialized into `T`.
-    ///
-    /// This is intended to be used in the implementations of [`Protocol::verify_direct_message_is_invalid`].
-    pub fn verify_is_not<P: Protocol, T: for<'de> Deserialize<'de>>(&self) -> Result<(), MessageValidationError> {
-        if self.deserialize::<P, T>().is_err() {
-            Ok(())
-        } else {
-            Err(MessageValidationError::InvalidEvidence(
-                "Message deserialized successfully".into(),
-            ))
-        }
-    }
-
-    /// Returns `Ok(())` if the message contains a payload.
-    ///
-    /// This is intended to be used in the implementations of [`Protocol::verify_direct_message_is_invalid`].
-    pub fn verify_is_some(&self) -> Result<(), MessageValidationError> {
-        if self.0.is_some() {
-            Ok(())
-        } else {
-            Err(MessageValidationError::InvalidEvidence(
-                "Message's payload is None".into(),
-            ))
-        }
-    }
-
-    /// Deserializes the direct message.
-    pub fn deserialize<P: Protocol, T: for<'de> Deserialize<'de>>(&self) -> Result<T, DirectMessageError> {
-        let payload = self
-            .0
-            .as_ref()
-            .ok_or_else(|| DirectMessageError::new("The direct message is missing in the payload"))?;
-        P::deserialize(&payload.0).map_err(DirectMessageError::from)
+    pub trait ProtocolMessageWrapper: Sized {
+        fn new_inner(maybe_message: Option<MessagePayload>) -> Self;
+        fn maybe_message(&self) -> &Option<MessagePayload>;
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub(crate) struct EchoBroadcastPayload(#[serde(with = "SliceLike::<Base64>")] Box<[u8]>);
+use private::{MessagePayload, ProtocolMessageWrapper};
 
-/// A serialized echo broadcast.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct EchoBroadcast(Option<EchoBroadcastPayload>);
+/// A serialized part of the protocol message.
+///
+/// These would usually be generated separately by the round, but delivered together to
+/// [`Round::receive_message`](`crate::protocol::Round::receive_message`).
+pub trait ProtocolMessagePart: ProtocolMessageWrapper {
+    /// The error specific to deserializing this message.
+    ///
+    /// Used to distinguish which deserialization failed in
+    /// [`Round::receive_message`](`crate::protocol::Round::receive_message`)
+    /// and store the corresponding message in the evidence.
+    type Error: From<String>;
 
-impl EchoBroadcast {
     /// Creates an empty message.
     ///
     /// Use in case the round does not send a message of this type.
-    pub fn none() -> Self {
-        Self(None)
+    fn none() -> Self {
+        Self::new_inner(None)
     }
 
-    /// Creates a new serialized echo broadcast.
-    pub fn new<P: Protocol, T: Serialize>(message: T) -> Result<Self, LocalError> {
-        Ok(Self(Some(EchoBroadcastPayload(P::serialize(message)?))))
+    /// Creates a new serialized message.
+    fn new<P: Protocol, T: Serialize>(message: T) -> Result<Self, LocalError> {
+        let payload = MessagePayload(P::serialize(message)?);
+        Ok(Self::new_inner(Some(payload)))
     }
 
     /// Returns `true` if this is an empty message.
-    pub(crate) fn is_none(&self) -> bool {
-        self.0.is_none()
+    fn is_none(&self) -> bool {
+        self.maybe_message().is_none()
     }
 
     /// Returns `Ok(())` if the message is indeed an empty message.
-    pub fn assert_is_none(&self) -> Result<(), EchoBroadcastError> {
+    fn assert_is_none(&self) -> Result<(), Self::Error> {
         if self.is_none() {
             Ok(())
         } else {
-            Err(EchoBroadcastError::new("The expected echo broadcast is missing"))
+            Err("The payload was expected to contain a message, but is `None`"
+                .to_string()
+                .into())
         }
     }
 
     /// Returns `Ok(())` if the message cannot be deserialized into `T`.
     ///
-    /// This is intended to be used in the implementations of [`Protocol::verify_direct_message_is_invalid`].
-    pub fn verify_is_not<P: Protocol, T: for<'de> Deserialize<'de>>(&self) -> Result<(), MessageValidationError> {
+    /// This is intended to be used in the implementations of
+    /// [`Protocol::verify_direct_message_is_invalid`] or [`Protocol::verify_echo_broadcast_is_invalid`].
+    fn verify_is_not<P: Protocol, T: for<'de> Deserialize<'de>>(&self) -> Result<(), MessageValidationError> {
         if self.deserialize::<P, T>().is_err() {
             Ok(())
         } else {
             Err(MessageValidationError::InvalidEvidence(
-                "Message deserialized successfully".into(),
+                "Message deserialized successfully, as expected by the protocol".into(),
             ))
         }
     }
 
     /// Returns `Ok(())` if the message contains a payload.
     ///
-    /// This is intended to be used in the implementations of [`Protocol::verify_direct_message_is_invalid`].
-    pub fn verify_is_some(&self) -> Result<(), MessageValidationError> {
-        if self.0.is_some() {
+    /// This is intended to be used in the implementations of
+    /// [`Protocol::verify_direct_message_is_invalid`] or [`Protocol::verify_echo_broadcast_is_invalid`].
+    fn verify_is_some(&self) -> Result<(), MessageValidationError> {
+        if self.maybe_message().is_some() {
             Ok(())
         } else {
             Err(MessageValidationError::InvalidEvidence(
-                "Message's payload is None".into(),
+                "The payload is `None`, as expected by the protocol".into(),
             ))
         }
     }
 
-    /// Deserializes the echo broadcast.
-    pub fn deserialize<P: Protocol, T: for<'de> Deserialize<'de>>(&self) -> Result<T, EchoBroadcastError> {
+    /// Deserializes the message into `T`.
+    fn deserialize<P: Protocol, T: for<'de> Deserialize<'de>>(&self) -> Result<T, Self::Error> {
         let payload = self
-            .0
+            .maybe_message()
             .as_ref()
-            .ok_or_else(|| EchoBroadcastError::new("The direct message is missing in the payload"))?;
-        P::deserialize(&payload.0).map_err(EchoBroadcastError::from)
+            .ok_or_else(|| "The payload is `None` and cannot be deserialized".into())?;
+        P::deserialize(&payload.0).map_err(|err| err.to_string().into())
     }
+}
+
+/// A serialized direct message.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DirectMessage(Option<MessagePayload>);
+
+impl ProtocolMessageWrapper for DirectMessage {
+    fn new_inner(maybe_message: Option<MessagePayload>) -> Self {
+        Self(maybe_message)
+    }
+
+    fn maybe_message(&self) -> &Option<MessagePayload> {
+        &self.0
+    }
+}
+
+impl ProtocolMessagePart for DirectMessage {
+    type Error = DirectMessageError;
+}
+
+/// A serialized echo broadcast.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct EchoBroadcast(Option<MessagePayload>);
+
+impl ProtocolMessageWrapper for EchoBroadcast {
+    fn new_inner(maybe_message: Option<MessagePayload>) -> Self {
+        Self(maybe_message)
+    }
+
+    fn maybe_message(&self) -> &Option<MessagePayload> {
+        &self.0
+    }
+}
+
+impl ProtocolMessagePart for EchoBroadcast {
+    type Error = EchoBroadcastError;
 }

--- a/manul/src/protocol/message.rs
+++ b/manul/src/protocol/message.rs
@@ -3,7 +3,7 @@ use alloc::string::{String, ToString};
 use serde::{Deserialize, Serialize};
 
 use super::{
-    errors::{DirectMessageError, EchoBroadcastError, LocalError, MessageValidationError},
+    errors::{DirectMessageError, EchoBroadcastError, LocalError, MessageValidationError, NormalBroadcastError},
     round::Protocol,
 };
 
@@ -136,4 +136,22 @@ impl ProtocolMessageWrapper for EchoBroadcast {
 
 impl ProtocolMessagePart for EchoBroadcast {
     type Error = EchoBroadcastError;
+}
+
+/// A serialized regular (non-echo) broadcast.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct NormalBroadcast(Option<MessagePayload>);
+
+impl ProtocolMessageWrapper for NormalBroadcast {
+    fn new_inner(maybe_message: Option<MessagePayload>) -> Self {
+        Self(maybe_message)
+    }
+
+    fn maybe_message(&self) -> &Option<MessagePayload> {
+        &self.0
+    }
+}
+
+impl ProtocolMessagePart for NormalBroadcast {
+    type Error = NormalBroadcastError;
 }

--- a/manul/src/protocol/round.rs
+++ b/manul/src/protocol/round.rs
@@ -13,7 +13,7 @@ use super::{
     errors::{
         DeserializationError, FinalizeError, LocalError, MessageValidationError, ProtocolValidationError, ReceiveError,
     },
-    message::{DirectMessage, EchoBroadcast},
+    message::{DirectMessage, EchoBroadcast, ProtocolMessagePart},
     object_safe::{ObjectSafeRound, ObjectSafeRoundWrapper},
 };
 

--- a/manul/src/protocol/round.rs
+++ b/manul/src/protocol/round.rs
@@ -13,7 +13,7 @@ use super::{
     errors::{
         DeserializationError, FinalizeError, LocalError, MessageValidationError, ProtocolValidationError, ReceiveError,
     },
-    message::{DirectMessage, EchoBroadcast, ProtocolMessagePart},
+    message::{DirectMessage, EchoBroadcast, NormalBroadcast, ProtocolMessagePart},
     object_safe::{ObjectSafeRound, ObjectSafeRoundWrapper},
 };
 
@@ -144,7 +144,7 @@ pub trait Protocol: Debug + Sized {
         #[allow(unused_variables)] message: &DirectMessage,
     ) -> Result<(), MessageValidationError> {
         Err(MessageValidationError::InvalidEvidence(format!(
-            "There are no direct messages in {round_id:?}"
+            "Invalid round number: {round_id:?}"
         )))
     }
 
@@ -157,7 +157,20 @@ pub trait Protocol: Debug + Sized {
         #[allow(unused_variables)] message: &EchoBroadcast,
     ) -> Result<(), MessageValidationError> {
         Err(MessageValidationError::InvalidEvidence(format!(
-            "There are no echo broadcasts in {round_id:?}"
+            "Invalid round number: {round_id:?}"
+        )))
+    }
+
+    /// Returns `Ok(())` if the given echo broadcast cannot be deserialized
+    /// assuming it is an echo broadcast from the round `round_id`.
+    ///
+    /// Normally one would use [`EchoBroadcast::verify_is_not`] when implementing this.
+    fn verify_normal_broadcast_is_invalid(
+        round_id: RoundId,
+        #[allow(unused_variables)] message: &NormalBroadcast,
+    ) -> Result<(), MessageValidationError> {
+        Err(MessageValidationError::InvalidEvidence(format!(
+            "Invalid round number: {round_id:?}"
         )))
     }
 }
@@ -178,6 +191,13 @@ pub trait ProtocolError: Debug + Clone + Send {
     ///
     /// **Note:** Should not include the round where the error happened.
     fn required_echo_broadcasts(&self) -> BTreeSet<RoundId> {
+        BTreeSet::new()
+    }
+
+    /// The rounds normal broadcasts from which are required to prove malicious behavior for this error.
+    ///
+    /// **Note:** Should not include the round where the error happened.
+    fn required_normal_broadcasts(&self) -> BTreeSet<RoundId> {
         BTreeSet::new()
     }
 
@@ -203,11 +223,14 @@ pub trait ProtocolError: Debug + Clone + Send {
     /// [`required_echo_broadcasts`](`Self::required_echo_broadcasts`).
     /// `combined_echos` are bundled echos from other parties from the previous rounds,
     /// as requested by [`required_combined_echos`](`Self::required_combined_echos`).
+    #[allow(clippy::too_many_arguments)]
     fn verify_messages_constitute_error(
         &self,
         echo_broadcast: &EchoBroadcast,
+        normal_broadcast: &NormalBroadcast,
         direct_message: &DirectMessage,
         echo_broadcasts: &BTreeMap<RoundId, EchoBroadcast>,
+        normal_broadcasts: &BTreeMap<RoundId, NormalBroadcast>,
         direct_messages: &BTreeMap<RoundId, DirectMessage>,
         combined_echos: &BTreeMap<RoundId, Vec<EchoBroadcast>>,
     ) -> Result<(), ProtocolValidationError>;
@@ -342,6 +365,7 @@ pub trait Round<Id>: 'static + Send + Sync + Debug {
     /// only via [`make_direct_message_with_artifact`](`Self::make_direct_message_with_artifact`).
     ///
     /// Return [`DirectMessage::none`] if this round does not send direct messages.
+    /// This is also the blanket implementation.
     fn make_direct_message(
         &self,
         #[allow(unused_variables)] rng: &mut impl CryptoRngCore,
@@ -350,9 +374,10 @@ pub trait Round<Id>: 'static + Send + Sync + Debug {
         Ok(DirectMessage::none())
     }
 
-    /// Returns the echo broadcast for this round, or `None` if the round does not require echo-broadcasting.
+    /// Returns the echo broadcast for this round.
     ///
-    /// Returns `None` if not implemented.
+    /// Return [`EchoBroadcast::none`] if this round does not send echo-broadcast messages.
+    /// This is also the blanket implementation.
     ///
     /// The execution layer will guarantee that all the destinations are sure they all received the same broadcast.
     /// This also means that a message with the broadcasts from all nodes signed by each node is available
@@ -364,6 +389,20 @@ pub trait Round<Id>: 'static + Send + Sync + Debug {
         Ok(EchoBroadcast::none())
     }
 
+    /// Returns the normal broadcast for this round.
+    ///
+    /// Return [`NormalBroadcast::none`] if this round does not send normal broadcast messages.
+    /// This is also the blanket implementation.
+    ///
+    /// Unlike the echo broadcasts, these will be just sent to every node from [`Self::message_destinations`]
+    /// without any confirmation required.
+    fn make_normal_broadcast(
+        &self,
+        #[allow(unused_variables)] rng: &mut impl CryptoRngCore,
+    ) -> Result<NormalBroadcast, LocalError> {
+        Ok(NormalBroadcast::none())
+    }
+
     /// Processes the received message and generates the payload that will be used in [`finalize`](`Self::finalize`).
     ///
     /// Note that there is no need to authenticate the message at this point;
@@ -373,6 +412,7 @@ pub trait Round<Id>: 'static + Send + Sync + Debug {
         rng: &mut impl CryptoRngCore,
         from: &Id,
         echo_broadcast: EchoBroadcast,
+        normal_broadcast: NormalBroadcast,
         direct_message: DirectMessage,
     ) -> Result<Payload, ReceiveError<Id, Self::Protocol>>;
 
@@ -398,6 +438,12 @@ pub trait Round<Id>: 'static + Send + Sync + Debug {
     /// to return in [`make_echo_broadcast`](`Self::make_echo_broadcast`).
     fn serialize_echo_broadcast(message: impl Serialize) -> Result<EchoBroadcast, LocalError> {
         EchoBroadcast::new::<Self::Protocol, _>(message)
+    }
+
+    /// A convenience method to create a [`NormalBroadcast`] object
+    /// to return in [`make_normal_broadcast`](`Self::make_normal_broadcast`).
+    fn serialize_normal_broadcast(message: impl Serialize) -> Result<NormalBroadcast, LocalError> {
+        NormalBroadcast::new::<Self::Protocol, _>(message)
     }
 
     /// A convenience method to create a [`DirectMessage`] object

--- a/manul/src/session/echo.rs
+++ b/manul/src/session/echo.rs
@@ -18,7 +18,7 @@ use super::{
 use crate::{
     protocol::{
         Artifact, DirectMessage, EchoBroadcast, FinalizeError, FinalizeOutcome, ObjectSafeRound, Payload, Protocol,
-        ReceiveError, Round, RoundId,
+        ProtocolMessagePart, ReceiveError, Round, RoundId,
     },
     utils::SerializableMap,
 };

--- a/manul/src/session/evidence.rs
+++ b/manul/src/session/evidence.rs
@@ -13,7 +13,7 @@ use super::{
 use crate::{
     protocol::{
         DirectMessage, DirectMessageError, EchoBroadcast, EchoBroadcastError, MessageValidationError, Protocol,
-        ProtocolError, ProtocolValidationError, RoundId,
+        ProtocolError, ProtocolMessagePart, ProtocolValidationError, RoundId,
     },
     utils::SerializableMap,
 };
@@ -422,7 +422,9 @@ where
                     "Invalid attached message metadata".into(),
                 ));
             }
-            let echo_set = DirectMessage::deserialize::<P, EchoRoundMessage<SP>>(verified_combined_echo.payload())?;
+            let echo_set = verified_combined_echo
+                .payload()
+                .deserialize::<P, EchoRoundMessage<SP>>()?;
 
             let mut verified_echo_set = Vec::new();
             for (other_verifier, echo_broadcast) in echo_set.echo_broadcasts.iter() {

--- a/manul/src/session/evidence.rs
+++ b/manul/src/session/evidence.rs
@@ -193,6 +193,35 @@ where
                     }),
                 })
             }
+            EchoRoundError::TwiceSigned(from) => {
+                // We could avoid all this if we attached the SignedMessage objects
+                // directly to the error. But then it would have to be generic over `S`,
+                // which the `Round` trait knows nothing about.
+                let round_id = normal_broadcast.metadata().round_id().non_echo();
+                let we_received = transcript.get_echo_broadcast(round_id, &from)?;
+
+                let deserialized = normal_broadcast
+                    .payload()
+                    .deserialize::<P, EchoRoundMessage<SP>>()
+                    .map_err(|error| {
+                        LocalError::new(format!("Failed to deserialize the given direct message: {:?}", error))
+                    })?;
+                let echoed_to_us = deserialized.echo_broadcasts.get(&from).ok_or_else(|| {
+                    LocalError::new(format!(
+                        "The echo message from {from:?} is missing from the echo packet"
+                    ))
+                })?;
+
+                Ok(Self {
+                    guilty_party: from,
+                    description,
+                    evidence: EvidenceEnum::TwiceSignedBroadcasts(TwiceSignedBroadcastsEvidence {
+                        we_received,
+                        echoed_to_us: echoed_to_us.clone(),
+                        phantom: core::marker::PhantomData,
+                    }),
+                })
+            }
         }
     }
 
@@ -257,6 +286,7 @@ where
             EvidenceEnum::InvalidNormalBroadcast(evidence) => evidence.verify::<SP>(party),
             EvidenceEnum::InvalidEchoPack(evidence) => evidence.verify(party),
             EvidenceEnum::MismatchedBroadcasts(evidence) => evidence.verify::<SP>(party),
+            EvidenceEnum::TwiceSignedBroadcasts(evidence) => evidence.verify::<SP>(party),
         }
     }
 }
@@ -269,6 +299,7 @@ enum EvidenceEnum<P: Protocol, SP: SessionParameters> {
     InvalidNormalBroadcast(InvalidNormalBroadcastEvidence<P>),
     InvalidEchoPack(InvalidEchoPackEvidence<P, SP>),
     MismatchedBroadcasts(MismatchedBroadcastsEvidence<P>),
+    TwiceSignedBroadcasts(TwiceSignedBroadcastsEvidence<P>),
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -335,6 +366,37 @@ where
         let echoed_to_us = self.echoed_to_us.clone().verify::<P, SP>(verifier)?;
 
         if we_received.metadata() == echoed_to_us.metadata() && we_received.payload() != echoed_to_us.payload() {
+            return Ok(());
+        }
+
+        Err(EvidenceError::InvalidEvidence(
+            "The attached messages don't constitute malicious behavior".into(),
+        ))
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TwiceSignedBroadcastsEvidence<P: Protocol> {
+    we_received: SignedMessage<EchoBroadcast>,
+    echoed_to_us: SignedMessage<EchoBroadcast>,
+    phantom: core::marker::PhantomData<P>,
+}
+
+impl<P> TwiceSignedBroadcastsEvidence<P>
+where
+    P: Protocol,
+{
+    fn verify<SP>(&self, verifier: &SP::Verifier) -> Result<(), EvidenceError>
+    where
+        SP: SessionParameters,
+    {
+        let we_received = self.we_received.clone().verify::<P, SP>(verifier)?;
+        let echoed_to_us = self.echoed_to_us.clone().verify::<P, SP>(verifier)?;
+
+        if self.we_received != self.echoed_to_us
+            && we_received.metadata() == echoed_to_us.metadata()
+            && we_received.payload() == echoed_to_us.payload()
+        {
             return Ok(());
         }
 

--- a/manul/src/session/session.rs
+++ b/manul/src/session/session.rs
@@ -22,7 +22,7 @@ use super::{
 };
 use crate::protocol::{
     Artifact, DirectMessage, EchoBroadcast, FinalizeError, FinalizeOutcome, FirstRound, ObjectSafeRound,
-    ObjectSafeRoundWrapper, Payload, Protocol, ReceiveError, ReceiveErrorType, Round, RoundId,
+    ObjectSafeRoundWrapper, Payload, Protocol, ProtocolMessagePart, ReceiveError, ReceiveErrorType, Round, RoundId,
 };
 
 /// A set of types needed to execute a session.

--- a/manul/src/session/session.rs
+++ b/manul/src/session/session.rs
@@ -687,7 +687,7 @@ where
             }
             ReceiveErrorType::Echo(error) => {
                 let (_echo_broadcast, normal_broadcast, _direct_message) = processed.message.into_parts();
-                let evidence = Evidence::new_echo_round_error(&from, normal_broadcast, error, transcript)?;
+                let evidence = Evidence::new_echo_round_error(&from, normal_broadcast, error)?;
                 self.register_provable_error(&from, evidence)
             }
             ReceiveErrorType::Local(error) => Err(error),

--- a/manul/src/session/session.rs
+++ b/manul/src/session/session.rs
@@ -21,8 +21,9 @@ use super::{
     LocalError, RemoteError,
 };
 use crate::protocol::{
-    Artifact, DirectMessage, EchoBroadcast, FinalizeError, FinalizeOutcome, FirstRound, ObjectSafeRound,
-    ObjectSafeRoundWrapper, Payload, Protocol, ProtocolMessagePart, ReceiveError, ReceiveErrorType, Round, RoundId,
+    Artifact, DirectMessage, EchoBroadcast, FinalizeError, FinalizeOutcome, FirstRound, NormalBroadcast,
+    ObjectSafeRound, ObjectSafeRoundWrapper, Payload, Protocol, ProtocolMessagePart, ReceiveError, ReceiveErrorType,
+    Round, RoundId,
 };
 
 /// A set of types needed to execute a session.
@@ -108,6 +109,7 @@ pub struct Session<P: Protocol, SP: SessionParameters> {
     round: Box<dyn ObjectSafeRound<SP::Verifier, Protocol = P>>,
     message_destinations: BTreeSet<SP::Verifier>,
     echo_broadcast: SignedMessage<EchoBroadcast>,
+    normal_broadcast: SignedMessage<NormalBroadcast>,
     possible_next_rounds: BTreeSet<RoundId>,
     transcript: Transcript<P, SP>,
 }
@@ -159,8 +161,13 @@ where
         transcript: Transcript<P, SP>,
     ) -> Result<Self, LocalError> {
         let verifier = signer.verifying_key();
+
         let echo = round.make_echo_broadcast(rng)?;
         let echo_broadcast = SignedMessage::new::<P, SP>(rng, &signer, &session_id, round.id(), echo)?;
+
+        let normal = round.make_normal_broadcast(rng)?;
+        let normal_broadcast = SignedMessage::new::<P, SP>(rng, &signer, &session_id, round.id(), normal)?;
+
         let message_destinations = round.message_destinations().clone();
 
         let possible_next_rounds = if echo_broadcast.payload().is_none() {
@@ -175,6 +182,7 @@ where
             verifier,
             round,
             echo_broadcast,
+            normal_broadcast,
             possible_next_rounds,
             message_destinations,
             transcript,
@@ -213,6 +221,7 @@ where
             self.round.id(),
             direct_message,
             self.echo_broadcast.clone(),
+            self.normal_broadcast.clone(),
         )?;
 
         Ok((
@@ -357,6 +366,7 @@ where
             rng,
             message.from(),
             message.echo_broadcast().clone(),
+            message.normal_broadcast().clone(),
             message.direct_message().clone(),
         );
         // We could filter out and return a possible `LocalError` at this stage,
@@ -384,6 +394,7 @@ where
         let transcript = self.transcript.update(
             round_id,
             accum.echo_broadcasts,
+            accum.normal_broadcasts,
             accum.direct_messages,
             accum.provable_errors,
             accum.unprovable_errors,
@@ -404,6 +415,7 @@ where
         let transcript = self.transcript.update(
             round_id,
             accum.echo_broadcasts,
+            accum.normal_broadcasts,
             accum.direct_messages,
             accum.provable_errors,
             accum.unprovable_errors,
@@ -496,6 +508,7 @@ pub struct RoundAccumulator<P: Protocol, SP: SessionParameters> {
     artifacts: BTreeMap<SP::Verifier, Artifact>,
     cached: BTreeMap<SP::Verifier, BTreeMap<RoundId, VerifiedMessageBundle<SP>>>,
     echo_broadcasts: BTreeMap<SP::Verifier, SignedMessage<EchoBroadcast>>,
+    normal_broadcasts: BTreeMap<SP::Verifier, SignedMessage<NormalBroadcast>>,
     direct_messages: BTreeMap<SP::Verifier, SignedMessage<DirectMessage>>,
     provable_errors: BTreeMap<SP::Verifier, Evidence<P, SP>>,
     unprovable_errors: BTreeMap<SP::Verifier, RemoteError>,
@@ -515,6 +528,7 @@ where
             artifacts: BTreeMap::new(),
             cached: BTreeMap::new(),
             echo_broadcasts: BTreeMap::new(),
+            normal_broadcasts: BTreeMap::new(),
             direct_messages: BTreeMap::new(),
             provable_errors: BTreeMap::new(),
             unprovable_errors: BTreeMap::new(),
@@ -623,9 +637,12 @@ where
         let error = match processed.processed {
             Ok(payload) => {
                 // Note: only inserting the messages if they actually have a payload
-                let (echo_broadcast, direct_message) = processed.message.into_parts();
+                let (echo_broadcast, normal_broadcast, direct_message) = processed.message.into_parts();
                 if !echo_broadcast.payload().is_none() {
                     self.echo_broadcasts.insert(from.clone(), echo_broadcast);
+                }
+                if !normal_broadcast.payload().is_none() {
+                    self.normal_broadcasts.insert(from.clone(), normal_broadcast);
                 }
                 if !direct_message.payload().is_none() {
                     self.direct_messages.insert(from.clone(), direct_message);
@@ -638,18 +655,30 @@ where
 
         match error.0 {
             ReceiveErrorType::InvalidDirectMessage(error) => {
-                let (_echo_broadcast, direct_message) = processed.message.into_parts();
+                let (_echo_broadcast, _normal_broadcast, direct_message) = processed.message.into_parts();
                 let evidence = Evidence::new_invalid_direct_message(&from, direct_message, error);
                 self.register_provable_error(&from, evidence)
             }
             ReceiveErrorType::InvalidEchoBroadcast(error) => {
-                let (echo_broadcast, _direct_message) = processed.message.into_parts();
+                let (echo_broadcast, _normal_broadcast, _direct_message) = processed.message.into_parts();
                 let evidence = Evidence::new_invalid_echo_broadcast(&from, echo_broadcast, error);
                 self.register_provable_error(&from, evidence)
             }
+            ReceiveErrorType::InvalidNormalBroadcast(error) => {
+                let (_echo_broadcast, normal_broadcast, _direct_message) = processed.message.into_parts();
+                let evidence = Evidence::new_invalid_normal_broadcast(&from, normal_broadcast, error);
+                self.register_provable_error(&from, evidence)
+            }
             ReceiveErrorType::Protocol(error) => {
-                let (echo_broadcast, direct_message) = processed.message.into_parts();
-                let evidence = Evidence::new_protocol_error(&from, echo_broadcast, direct_message, error, transcript)?;
+                let (echo_broadcast, normal_broadcast, direct_message) = processed.message.into_parts();
+                let evidence = Evidence::new_protocol_error(
+                    &from,
+                    echo_broadcast,
+                    normal_broadcast,
+                    direct_message,
+                    error,
+                    transcript,
+                )?;
                 self.register_provable_error(&from, evidence)
             }
             ReceiveErrorType::Unprovable(error) => {
@@ -657,8 +686,8 @@ where
                 Ok(())
             }
             ReceiveErrorType::Echo(error) => {
-                let (_echo_broadcast, direct_message) = processed.message.into_parts();
-                let evidence = Evidence::new_echo_round_error(&from, direct_message, error, transcript)?;
+                let (_echo_broadcast, normal_broadcast, _direct_message) = processed.message.into_parts();
+                let evidence = Evidence::new_echo_round_error(&from, normal_broadcast, error, transcript)?;
                 self.register_provable_error(&from, evidence)
             }
             ReceiveErrorType::Local(error) => Err(error),
@@ -711,7 +740,7 @@ mod tests {
     use super::{MessageBundle, ProcessedArtifact, ProcessedMessage, Session, VerifiedMessageBundle};
     use crate::{
         protocol::{
-            DeserializationError, DirectMessage, EchoBroadcast, LocalError, Protocol, ProtocolError,
+            DeserializationError, DirectMessage, EchoBroadcast, LocalError, NormalBroadcast, Protocol, ProtocolError,
             ProtocolValidationError, RoundId,
         },
         testing::TestSessionParams,
@@ -737,8 +766,10 @@ mod tests {
             fn verify_messages_constitute_error(
                 &self,
                 _echo_broadcast: &EchoBroadcast,
+                _normal_broadcast: &NormalBroadcast,
                 _direct_message: &DirectMessage,
                 _echo_broadcasts: &BTreeMap<RoundId, EchoBroadcast>,
+                _normal_broadcasts: &BTreeMap<RoundId, NormalBroadcast>,
                 _direct_messages: &BTreeMap<RoundId, DirectMessage>,
                 _combined_echos: &BTreeMap<RoundId, Vec<EchoBroadcast>>,
             ) -> Result<(), ProtocolValidationError> {


### PR DESCRIPTION
Fixes #24 

- `EchoBroadcast` and `DirectMessage` now use `ProtocolMessagePart` trait for their methods.
- Added normal broadcasts support in addition to echo ones; signatures of `Round` methods changed accordingly.
- Added `Round::make_normal_broadcast()`.
- Added processing of a mismatched signature in the echoed broadcast. It is a provable error now.
- Simplified creating an evidence for an echo round error (the TODO about `SignedMessage` being generic over signatures does not apply anymore)