### PR TITLE
Various evidence-related fixes

### DIFF
--- a/examples/src/simple.rs
+++ b/examples/src/simple.rs
@@ -1,4 +1,8 @@
-use alloc::collections::{BTreeMap, BTreeSet};
+use alloc::{
+    collections::{BTreeMap, BTreeSet},
+    format,
+    string::String,
+};
 use core::fmt::Debug;
 
 use manul::protocol::*;
@@ -15,6 +19,10 @@ pub enum SimpleProtocolError {
 }
 
 impl ProtocolError for SimpleProtocolError {
+    fn description(&self) -> String {
+        format!("{:?}", self)
+    }
+
     fn required_direct_messages(&self) -> BTreeSet<RoundId> {
         match self {
             Self::Round1InvalidPosition => BTreeSet::new(),

--- a/examples/src/simple_malicious.rs
+++ b/examples/src/simple_malicious.rs
@@ -188,8 +188,8 @@ fn serialized_garbage() {
     let report1 = reports.remove(&v1).unwrap();
     let report2 = reports.remove(&v2).unwrap();
 
-    assert!(report1.provable_errors[&v0].verify(&v0).is_ok());
-    assert!(report2.provable_errors[&v0].verify(&v0).is_ok());
+    assert!(report1.provable_errors[&v0].verify().is_ok());
+    assert!(report2.provable_errors[&v0].verify().is_ok());
 }
 
 #[test]
@@ -234,8 +234,8 @@ fn attributable_failure() {
     let report1 = reports.remove(&v1).unwrap();
     let report2 = reports.remove(&v2).unwrap();
 
-    assert!(report1.provable_errors[&v0].verify(&v0).is_ok());
-    assert!(report2.provable_errors[&v0].verify(&v0).is_ok());
+    assert!(report1.provable_errors[&v0].verify().is_ok());
+    assert!(report2.provable_errors[&v0].verify().is_ok());
 }
 
 #[test]
@@ -280,6 +280,6 @@ fn attributable_failure_round2() {
     let report1 = reports.remove(&v1).unwrap();
     let report2 = reports.remove(&v2).unwrap();
 
-    assert!(report1.provable_errors[&v0].verify(&v0).is_ok());
-    assert!(report2.provable_errors[&v0].verify(&v0).is_ok());
+    assert!(report1.provable_errors[&v0].verify().is_ok());
+    assert!(report2.provable_errors[&v0].verify().is_ok());
 }

--- a/manul/benches/empty_rounds.rs
+++ b/manul/benches/empty_rounds.rs
@@ -1,6 +1,9 @@
 extern crate alloc;
 
-use alloc::collections::{BTreeMap, BTreeSet};
+use alloc::{
+    collections::{BTreeMap, BTreeSet},
+    string::String,
+};
 use core::fmt::Debug;
 
 use criterion::{criterion_group, criterion_main, Criterion};
@@ -23,6 +26,9 @@ pub struct EmptyProtocol;
 pub struct EmptyProtocolError;
 
 impl ProtocolError for EmptyProtocolError {
+    fn description(&self) -> String {
+        unimplemented!()
+    }
     fn verify_messages_constitute_error(
         &self,
         _deserializer: &Deserializer,

--- a/manul/src/protocol/round.rs
+++ b/manul/src/protocol/round.rs
@@ -84,6 +84,11 @@ impl RoundId {
         }
     }
 
+    /// Returns `true` if this is an ID of an echo broadcast round.
+    pub(crate) fn is_echo(&self) -> bool {
+        self.is_echo
+    }
+
     /// Returns the identifier of the echo round corresponding to the given non-echo round.
     ///
     /// Panics if `self` is already an echo round identifier.
@@ -161,6 +166,7 @@ pub trait Protocol: 'static + Sized {
     ///
     /// Normally one would use [`EchoBroadcast::verify_is_not`] when implementing this.
     fn verify_normal_broadcast_is_invalid(
+        #[allow(unused_variables)] deserializer: &Deserializer,
         round_id: RoundId,
         #[allow(unused_variables)] message: &NormalBroadcast,
     ) -> Result<(), MessageValidationError> {

--- a/manul/src/protocol/round.rs
+++ b/manul/src/protocol/round.rs
@@ -2,6 +2,7 @@ use alloc::{
     boxed::Box,
     collections::{BTreeMap, BTreeSet},
     format,
+    string::String,
     vec::Vec,
 };
 use core::{any::Any, fmt::Debug};
@@ -121,7 +122,7 @@ impl RoundId {
 }
 
 /// A distributed protocol.
-pub trait Protocol: 'static + Sized {
+pub trait Protocol: 'static {
     /// The successful result of an execution of this protocol.
     type Result: Debug;
 
@@ -181,6 +182,11 @@ pub trait Protocol: 'static + Sized {
 /// Provable here means that we can create an evidence object entirely of messages signed by some party,
 /// which, in combination, prove the party's malicious actions.
 pub trait ProtocolError: Debug + Clone + Send {
+    /// A description of the error that will be included in the generated evidence.
+    ///
+    /// Make it short and informative.
+    fn description(&self) -> String;
+
     /// The rounds direct messages from which are required to prove malicious behavior for this error.
     ///
     /// **Note:** Should not include the round where the error happened.

--- a/manul/src/session.rs
+++ b/manul/src/session.rs
@@ -16,6 +16,7 @@ mod transcript;
 mod wire_format;
 
 pub use crate::protocol::{LocalError, RemoteError};
+pub use evidence::{Evidence, EvidenceError};
 pub use message::MessageBundle;
 pub use session::{CanFinalize, RoundAccumulator, RoundOutcome, Session, SessionId, SessionParameters};
 pub use transcript::{SessionOutcome, SessionReport};

--- a/manul/src/session/echo.rs
+++ b/manul/src/session/echo.rs
@@ -2,6 +2,7 @@ use alloc::{
     boxed::Box,
     collections::{BTreeMap, BTreeSet},
     format,
+    string::String,
     vec::Vec,
 };
 use core::fmt::Debug;
@@ -44,6 +45,17 @@ pub(crate) enum EchoRoundError<Id> {
         we_received: SignedMessage<EchoBroadcast>,
         echoed_to_us: SignedMessage<EchoBroadcast>,
     },
+}
+
+impl<Id> EchoRoundError<Id> {
+    pub(crate) fn description(&self) -> String {
+        match self {
+            Self::InvalidEcho(_) => "Invalid message received among the ones echoed".into(),
+            Self::MismatchedBroadcasts { .. } => {
+                "The echoed message is different from the originally received one".into()
+            }
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize)]

--- a/manul/src/session/evidence.rs
+++ b/manul/src/session/evidence.rs
@@ -250,18 +250,18 @@ where
     }
 
     /// Attempts to verify that the attached data constitutes enough evidence
-    /// to prove the malicious behavior.
+    /// to prove the malicious behavior of [`Self::guilty_party`].
     ///
     /// Returns `Ok(())` if it is the case.
-    pub fn verify(&self, party: &SP::Verifier) -> Result<(), EvidenceError> {
+    pub fn verify(&self) -> Result<(), EvidenceError> {
         let deserializer = Deserializer::new::<SP::WireFormat>();
         match &self.evidence {
-            EvidenceEnum::Protocol(evidence) => evidence.verify::<SP>(party, &deserializer),
-            EvidenceEnum::InvalidDirectMessage(evidence) => evidence.verify::<SP>(party, &deserializer),
-            EvidenceEnum::InvalidEchoBroadcast(evidence) => evidence.verify::<SP>(party, &deserializer),
-            EvidenceEnum::InvalidNormalBroadcast(evidence) => evidence.verify::<SP>(party, &deserializer),
-            EvidenceEnum::InvalidEchoPack(evidence) => evidence.verify(party, &deserializer),
-            EvidenceEnum::MismatchedBroadcasts(evidence) => evidence.verify::<SP>(party),
+            EvidenceEnum::Protocol(evidence) => evidence.verify::<SP>(&self.guilty_party, &deserializer),
+            EvidenceEnum::InvalidDirectMessage(evidence) => evidence.verify::<SP>(&self.guilty_party, &deserializer),
+            EvidenceEnum::InvalidEchoBroadcast(evidence) => evidence.verify::<SP>(&self.guilty_party, &deserializer),
+            EvidenceEnum::InvalidNormalBroadcast(evidence) => evidence.verify::<SP>(&self.guilty_party, &deserializer),
+            EvidenceEnum::InvalidEchoPack(evidence) => evidence.verify(&self.guilty_party, &deserializer),
+            EvidenceEnum::MismatchedBroadcasts(evidence) => evidence.verify::<SP>(&self.guilty_party),
         }
     }
 }

--- a/manul/src/session/evidence.rs
+++ b/manul/src/session/evidence.rs
@@ -1,4 +1,9 @@
-use alloc::{collections::BTreeMap, format, string::String, vec::Vec};
+use alloc::{
+    collections::BTreeMap,
+    format,
+    string::{String, ToString},
+    vec::Vec,
+};
 use core::fmt::Debug;
 
 use serde::{Deserialize, Serialize};
@@ -139,7 +144,7 @@ where
             })
             .collect::<Result<BTreeMap<_, _>, _>>()?;
 
-        let description = format!("Protocol error: {:?}", error);
+        let description = format!("Protocol error: {}", error.description());
 
         Ok(Self {
             guilty_party: verifier.clone(),
@@ -162,7 +167,7 @@ where
         normal_broadcast: SignedMessage<NormalBroadcast>,
         error: EchoRoundError<SP::Verifier>,
     ) -> Result<Self, LocalError> {
-        let description = format!("{:?}", error);
+        let description = format!("Echo round error: {}", error.description());
         match error {
             EchoRoundError::InvalidEcho(from) => Ok(Self {
                 guilty_party: verifier.clone(),
@@ -196,7 +201,7 @@ where
     ) -> Self {
         Self {
             guilty_party: verifier.clone(),
-            description: format!("{:?}", error),
+            description: error.to_string(),
             evidence: EvidenceEnum::InvalidDirectMessage(InvalidDirectMessageEvidence {
                 direct_message,
                 phantom: core::marker::PhantomData,
@@ -211,7 +216,7 @@ where
     ) -> Self {
         Self {
             guilty_party: verifier.clone(),
-            description: format!("{:?}", error),
+            description: error.to_string(),
             evidence: EvidenceEnum::InvalidEchoBroadcast(InvalidEchoBroadcastEvidence {
                 echo_broadcast,
                 phantom: core::marker::PhantomData,
@@ -226,7 +231,7 @@ where
     ) -> Self {
         Self {
             guilty_party: verifier.clone(),
-            description: format!("{:?}", error),
+            description: error.to_string(),
             evidence: EvidenceEnum::InvalidNormalBroadcast(InvalidNormalBroadcastEvidence {
                 normal_broadcast,
                 phantom: core::marker::PhantomData,

--- a/manul/src/session/session.rs
+++ b/manul/src/session/session.rs
@@ -771,7 +771,7 @@ fn filter_messages<SP: SessionParameters>(
 
 #[cfg(test)]
 mod tests {
-    use alloc::{collections::BTreeMap, vec::Vec};
+    use alloc::{collections::BTreeMap, string::String, vec::Vec};
 
     use impls::impls;
     use serde::{Deserialize, Serialize};
@@ -801,6 +801,10 @@ mod tests {
         struct DummyProtocolError;
 
         impl ProtocolError for DummyProtocolError {
+            fn description(&self) -> String {
+                unimplemented!()
+            }
+
             fn verify_messages_constitute_error(
                 &self,
                 _deserializer: &Deserializer,


### PR DESCRIPTION
- Add `Evidence` to public exports and add docs.
- Fixes #49 
- Fixes #52
- Fixes #51
- Don't require a verifier argument to `Evidence::verify()` - we already have it in the struct.
