### PR TITLE
Simplify public-facing message API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `EchoBroadcast` and `DirectMessage` now use `ProtocolMessagePart` trait for their methods. ([#47])
 - Added normal broadcasts support in addition to echo ones; signatures of `Round` methods changed accordingly; added `Round::make_normal_broadcast()`. ([#47])
 - Serialization format is a part of `SessionParameters` now; `Round` and `Protocol` methods receive dynamic serializers/deserializers. ([#33])
+- Renamed `(Verified)MessageBundle` to `(Verified)Message`. ([#56])
 
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `SerializableMap` wrapper for `BTreeMap` supporting more formats and providing some safety features. (#[32])
 - `DirectMessage::assert_is_none()` and `verify_is_some()`, same for `EchoBroadcast`. Users can now check that a part of the round message (echo or direct) is `None` as expected, and make a verifiable evidence if it is not. ([#46])
+- Re-export `digest` from the `session` module. ([#56])
 
 
 [#32]: https://github.com/entropyxyz/manul/pull/32
@@ -35,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#41]: https://github.com/entropyxyz/manul/pull/41
 [#46]: https://github.com/entropyxyz/manul/pull/46
 [#47]: https://github.com/entropyxyz/manul/pull/47
+[#56]: https://github.com/entropyxyz/manul/pull/56
 
 
 ## [0.0.1] - 2024-10-12

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `EchoBroadcast` and `DirectMessage` now use `ProtocolMessagePart` trait for their methods. ([#47])
 - Added normal broadcasts support in addition to echo ones; signatures of `Round` methods changed accordingly; added `Round::make_normal_broadcast()`. ([#47])
 - Serialization format is a part of `SessionParameters` now; `Round` and `Protocol` methods receive dynamic serializers/deserializers. ([#33])
-- Renamed `(Verified)MessageBundle` to `(Verified)Message`. ([#56])
+- Renamed `(Verified)MessageBundle` to `(Verified)Message`. Both are now generic over `Verifier`. ([#56])
 
 
 ### Added
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `SerializableMap` wrapper for `BTreeMap` supporting more formats and providing some safety features. (#[32])
 - `DirectMessage::assert_is_none()` and `verify_is_some()`, same for `EchoBroadcast`. Users can now check that a part of the round message (echo or direct) is `None` as expected, and make a verifiable evidence if it is not. ([#46])
 - Re-export `digest` from the `session` module. ([#56])
+- Added `Message::destination()`. ([#56])
 
 
 [#32]: https://github.com/entropyxyz/manul/pull/32

--- a/examples/tests/async_runner.rs
+++ b/examples/tests/async_runner.rs
@@ -23,12 +23,12 @@ use tracing_subscriber::{util::SubscriberInitExt, EnvFilter};
 struct MessageOut<SP: SessionParameters> {
     from: SP::Verifier,
     to: SP::Verifier,
-    message: Message,
+    message: Message<SP::Verifier>,
 }
 
 struct MessageIn<SP: SessionParameters> {
     from: SP::Verifier,
-    message: Message,
+    message: Message<SP::Verifier>,
 }
 
 /// Runs a session. Simulates what each participating party would run as the protocol progresses.

--- a/examples/tests/async_runner.rs
+++ b/examples/tests/async_runner.rs
@@ -5,8 +5,8 @@ use alloc::collections::{BTreeMap, BTreeSet};
 use manul::{
     protocol::Protocol,
     session::{
-        signature::Keypair, CanFinalize, LocalError, MessageBundle, RoundOutcome, Session, SessionId,
-        SessionParameters, SessionReport,
+        signature::Keypair, CanFinalize, LocalError, Message, RoundOutcome, Session, SessionId, SessionParameters,
+        SessionReport,
     },
     testing::{BinaryFormat, TestSessionParams, TestSigner},
 };
@@ -23,12 +23,12 @@ use tracing_subscriber::{util::SubscriberInitExt, EnvFilter};
 struct MessageOut<SP: SessionParameters> {
     from: SP::Verifier,
     to: SP::Verifier,
-    message: MessageBundle,
+    message: Message,
 }
 
 struct MessageIn<SP: SessionParameters> {
     from: SP::Verifier,
-    message: MessageBundle,
+    message: Message,
 }
 
 /// Runs a session. Simulates what each participating party would run as the protocol progresses.

--- a/manul/src/session.rs
+++ b/manul/src/session.rs
@@ -17,12 +17,12 @@ mod wire_format;
 
 pub use crate::protocol::{LocalError, RemoteError};
 pub use evidence::{Evidence, EvidenceError};
-pub use message::MessageBundle;
+pub use message::{VerifiedMessage, Message};
 pub use session::{CanFinalize, RoundAccumulator, RoundOutcome, Session, SessionId, SessionParameters};
 pub use transcript::{SessionOutcome, SessionReport};
 pub use wire_format::WireFormat;
 
 pub(crate) use echo::EchoRoundError;
 
-pub use signature;
 pub use digest;
+pub use signature;

--- a/manul/src/session.rs
+++ b/manul/src/session.rs
@@ -25,3 +25,4 @@ pub use wire_format::WireFormat;
 pub(crate) use echo::EchoRoundError;
 
 pub use signature;
+pub use digest;

--- a/manul/src/session.rs
+++ b/manul/src/session.rs
@@ -17,7 +17,7 @@ mod wire_format;
 
 pub use crate::protocol::{LocalError, RemoteError};
 pub use evidence::{Evidence, EvidenceError};
-pub use message::{VerifiedMessage, Message};
+pub use message::{Message, VerifiedMessage};
 pub use session::{CanFinalize, RoundAccumulator, RoundOutcome, Session, SessionId, SessionParameters};
 pub use transcript::{SessionOutcome, SessionReport};
 pub use wire_format::WireFormat;

--- a/manul/src/session/echo.rs
+++ b/manul/src/session/echo.rs
@@ -12,7 +12,7 @@ use serde::{Deserialize, Serialize};
 use tracing::debug;
 
 use super::{
-    message::{MessageVerificationError, SignedMessage},
+    message::{MessageVerificationError, SignedMessagePart},
     session::SessionParameters,
     LocalError,
 };
@@ -42,8 +42,8 @@ pub(crate) enum EchoRoundError<Id> {
     MismatchedBroadcasts {
         guilty_party: Id,
         error: MismatchedBroadcastsError,
-        we_received: SignedMessage<EchoBroadcast>,
-        echoed_to_us: SignedMessage<EchoBroadcast>,
+        we_received: SignedMessagePart<EchoBroadcast>,
+        echoed_to_us: SignedMessagePart<EchoBroadcast>,
     },
 }
 
@@ -68,7 +68,7 @@ pub(crate) enum MismatchedBroadcastsError {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub(crate) struct EchoRoundMessage<SP: SessionParameters> {
-    pub(super) echo_broadcasts: SerializableMap<SP::Verifier, SignedMessage<EchoBroadcast>>,
+    pub(super) echo_broadcasts: SerializableMap<SP::Verifier, SignedMessagePart<EchoBroadcast>>,
 }
 
 /// Each protocol round can contain one `EchoRound` with "echo messages" that are sent to all
@@ -77,7 +77,7 @@ pub(crate) struct EchoRoundMessage<SP: SessionParameters> {
 #[derive_where::derive_where(Debug)]
 pub struct EchoRound<P, SP: SessionParameters> {
     verifier: SP::Verifier,
-    echo_broadcasts: BTreeMap<SP::Verifier, SignedMessage<EchoBroadcast>>,
+    echo_broadcasts: BTreeMap<SP::Verifier, SignedMessagePart<EchoBroadcast>>,
     destinations: BTreeSet<SP::Verifier>,
     expected_echos: BTreeSet<SP::Verifier>,
     main_round: Box<dyn ObjectSafeRound<SP::Verifier, Protocol = P>>,
@@ -92,8 +92,8 @@ where
 {
     pub fn new(
         verifier: SP::Verifier,
-        my_echo_broadcast: SignedMessage<EchoBroadcast>,
-        echo_broadcasts: BTreeMap<SP::Verifier, SignedMessage<EchoBroadcast>>,
+        my_echo_broadcast: SignedMessagePart<EchoBroadcast>,
+        echo_broadcasts: BTreeMap<SP::Verifier, SignedMessagePart<EchoBroadcast>>,
         main_round: Box<dyn ObjectSafeRound<SP::Verifier, Protocol = P>>,
         payloads: BTreeMap<SP::Verifier, Payload>,
         artifacts: BTreeMap<SP::Verifier, Artifact>,

--- a/manul/src/session/evidence.rs
+++ b/manul/src/session/evidence.rs
@@ -37,15 +37,6 @@ pub enum EvidenceError {
     InvalidEvidence(String),
 }
 
-// Other nodes would send a signed message with the payload being either Some(...) or None.
-// We expect the messages in the evidence only be the Some(...) ones, so if it's not the case, it's invalid evidence.
-// It's hard to enforce statically since we have to keep the signed messages as they were created by remote nodes.
-impl From<MissingMessage> for EvidenceError {
-    fn from(_error: MissingMessage) -> Self {
-        Self::InvalidEvidence("The signed message is missing the expected payload".into())
-    }
-}
-
 impl From<MessageVerificationError> for EvidenceError {
     fn from(error: MessageVerificationError) -> Self {
         match error {

--- a/manul/src/session/evidence.rs
+++ b/manul/src/session/evidence.rs
@@ -10,7 +10,7 @@ use serde::{Deserialize, Serialize};
 
 use super::{
     echo::{EchoRound, EchoRoundError, EchoRoundMessage, MismatchedBroadcastsError},
-    message::{MessageVerificationError, MissingMessage, SignedMessage},
+    message::{MessageVerificationError, SignedMessagePart},
     session::SessionParameters,
     transcript::Transcript,
     LocalError,
@@ -89,9 +89,9 @@ where
 {
     pub(crate) fn new_protocol_error(
         verifier: &SP::Verifier,
-        echo_broadcast: SignedMessage<EchoBroadcast>,
-        normal_broadcast: SignedMessage<NormalBroadcast>,
-        direct_message: SignedMessage<DirectMessage>,
+        echo_broadcast: SignedMessagePart<EchoBroadcast>,
+        normal_broadcast: SignedMessagePart<NormalBroadcast>,
+        direct_message: SignedMessagePart<DirectMessage>,
         error: P::ProtocolError,
         transcript: &Transcript<P, SP>,
     ) -> Result<Self, LocalError> {
@@ -155,7 +155,7 @@ where
 
     pub(crate) fn new_echo_round_error(
         verifier: &SP::Verifier,
-        normal_broadcast: SignedMessage<NormalBroadcast>,
+        normal_broadcast: SignedMessagePart<NormalBroadcast>,
         error: EchoRoundError<SP::Verifier>,
     ) -> Result<Self, LocalError> {
         let description = format!("Echo round error: {}", error.description());
@@ -187,7 +187,7 @@ where
 
     pub(crate) fn new_invalid_direct_message(
         verifier: &SP::Verifier,
-        direct_message: SignedMessage<DirectMessage>,
+        direct_message: SignedMessagePart<DirectMessage>,
         error: DirectMessageError,
     ) -> Self {
         Self {
@@ -202,7 +202,7 @@ where
 
     pub(crate) fn new_invalid_echo_broadcast(
         verifier: &SP::Verifier,
-        echo_broadcast: SignedMessage<EchoBroadcast>,
+        echo_broadcast: SignedMessagePart<EchoBroadcast>,
         error: EchoBroadcastError,
     ) -> Self {
         Self {
@@ -217,7 +217,7 @@ where
 
     pub(crate) fn new_invalid_normal_broadcast(
         verifier: &SP::Verifier,
-        normal_broadcast: SignedMessage<NormalBroadcast>,
+        normal_broadcast: SignedMessagePart<NormalBroadcast>,
         error: NormalBroadcastError,
     ) -> Self {
         Self {
@@ -271,7 +271,7 @@ enum EvidenceEnum<P: Protocol, SP: SessionParameters> {
 #[derive_where::derive_where(Debug)]
 #[derive(Clone, Serialize, Deserialize)]
 pub struct InvalidEchoPackEvidence<SP: SessionParameters> {
-    normal_broadcast: SignedMessage<NormalBroadcast>,
+    normal_broadcast: SignedMessagePart<NormalBroadcast>,
     invalid_echo_sender: SP::Verifier,
 }
 
@@ -315,8 +315,8 @@ where
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct MismatchedBroadcastsEvidence {
     error: MismatchedBroadcastsError,
-    we_received: SignedMessage<EchoBroadcast>,
-    echoed_to_us: SignedMessage<EchoBroadcast>,
+    we_received: SignedMessagePart<EchoBroadcast>,
+    echoed_to_us: SignedMessagePart<EchoBroadcast>,
 }
 
 impl MismatchedBroadcastsEvidence {
@@ -351,7 +351,7 @@ impl MismatchedBroadcastsEvidence {
 #[derive_where::derive_where(Debug)]
 #[derive(Clone, Serialize, Deserialize)]
 pub struct InvalidDirectMessageEvidence<P: Protocol> {
-    direct_message: SignedMessage<DirectMessage>,
+    direct_message: SignedMessagePart<DirectMessage>,
     phantom: core::marker::PhantomData<P>,
 }
 
@@ -381,7 +381,7 @@ where
 #[derive_where::derive_where(Debug)]
 #[derive(Clone, Serialize, Deserialize)]
 pub struct InvalidEchoBroadcastEvidence<P: Protocol> {
-    echo_broadcast: SignedMessage<EchoBroadcast>,
+    echo_broadcast: SignedMessagePart<EchoBroadcast>,
     phantom: core::marker::PhantomData<P>,
 }
 
@@ -411,7 +411,7 @@ where
 #[derive_where::derive_where(Debug)]
 #[derive(Clone, Serialize, Deserialize)]
 pub struct InvalidNormalBroadcastEvidence<P: Protocol> {
-    normal_broadcast: SignedMessage<NormalBroadcast>,
+    normal_broadcast: SignedMessagePart<NormalBroadcast>,
     phantom: core::marker::PhantomData<P>,
 }
 
@@ -445,13 +445,13 @@ where
 #[derive(Clone, Serialize, Deserialize)]
 struct ProtocolEvidence<P: Protocol> {
     error: P::ProtocolError,
-    direct_message: SignedMessage<DirectMessage>,
-    echo_broadcast: SignedMessage<EchoBroadcast>,
-    normal_broadcast: SignedMessage<NormalBroadcast>,
-    direct_messages: SerializableMap<RoundId, SignedMessage<DirectMessage>>,
-    echo_broadcasts: SerializableMap<RoundId, SignedMessage<EchoBroadcast>>,
-    normal_broadcasts: SerializableMap<RoundId, SignedMessage<NormalBroadcast>>,
-    combined_echos: SerializableMap<RoundId, SignedMessage<NormalBroadcast>>,
+    direct_message: SignedMessagePart<DirectMessage>,
+    echo_broadcast: SignedMessagePart<EchoBroadcast>,
+    normal_broadcast: SignedMessagePart<NormalBroadcast>,
+    direct_messages: SerializableMap<RoundId, SignedMessagePart<DirectMessage>>,
+    echo_broadcasts: SerializableMap<RoundId, SignedMessagePart<EchoBroadcast>>,
+    normal_broadcasts: SerializableMap<RoundId, SignedMessagePart<NormalBroadcast>>,
+    combined_echos: SerializableMap<RoundId, SignedMessagePart<NormalBroadcast>>,
 }
 
 impl<P> ProtocolEvidence<P>

--- a/manul/src/session/message.rs
+++ b/manul/src/session/message.rs
@@ -152,9 +152,6 @@ where
     }
 }
 
-#[derive(Debug, Clone, Copy)]
-pub(crate) struct MissingMessage;
-
 #[derive(Debug, Clone)]
 pub struct VerifiedMessage<M> {
     signature: SerializedSignature,

--- a/manul/src/session/message.rs
+++ b/manul/src/session/message.rs
@@ -44,7 +44,7 @@ pub(crate) enum MessageVerificationError {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub(crate) struct SignedMessage<M> {
+pub(crate) struct SignedMessagePart<M> {
     signature: SerializedSignature,
     message_with_metadata: MessageWithMetadata<M>,
 }
@@ -84,7 +84,7 @@ impl<M: ProtocolMessagePart> MessageWithMetadata<M> {
         SP: SessionParameters,
     {
         let digest =
-            SP::Digest::new_with_prefix(b"SignedMessage").chain_update(SP::WireFormat::serialize(&self.metadata)?);
+            SP::Digest::new_with_prefix(b"SignedMessagePart").chain_update(SP::WireFormat::serialize(&self.metadata)?);
 
         let digest = match self.message.maybe_message().as_ref() {
             None => digest.chain_update([0u8]),
@@ -95,7 +95,7 @@ impl<M: ProtocolMessagePart> MessageWithMetadata<M> {
     }
 }
 
-impl<M> SignedMessage<M>
+impl<M> SignedMessagePart<M>
 where
     M: ProtocolMessagePart,
 {
@@ -129,7 +129,7 @@ where
         &self.message_with_metadata.message
     }
 
-    pub(crate) fn verify<SP>(self, verifier: &SP::Verifier) -> Result<VerifiedMessage<M>, MessageVerificationError>
+    pub(crate) fn verify<SP>(self, verifier: &SP::Verifier) -> Result<VerifiedMessagePart<M>, MessageVerificationError>
     where
         SP: SessionParameters,
     {
@@ -142,7 +142,7 @@ where
             .deserialize::<SP>()
             .map_err(|_| MessageVerificationError::InvalidSignature)?;
         if verifier.verify_digest(digest, &signature).is_ok() {
-            Ok(VerifiedMessage {
+            Ok(VerifiedMessagePart {
                 signature: self.signature,
                 message_with_metadata: self.message_with_metadata,
             })
@@ -153,12 +153,12 @@ where
 }
 
 #[derive(Debug, Clone)]
-pub struct VerifiedMessage<M> {
+pub struct VerifiedMessagePart<M> {
     signature: SerializedSignature,
     message_with_metadata: MessageWithMetadata<M>,
 }
 
-impl<M> VerifiedMessage<M> {
+impl<M> VerifiedMessagePart<M> {
     pub(crate) fn metadata(&self) -> &MessageMetadata {
         &self.message_with_metadata.metadata
     }
@@ -167,27 +167,23 @@ impl<M> VerifiedMessage<M> {
         &self.message_with_metadata.message
     }
 
-    pub fn into_unverified(self) -> SignedMessage<M> {
-        SignedMessage {
+    pub fn into_unverified(self) -> SignedMessagePart<M> {
+        SignedMessagePart {
             signature: self.signature,
             message_with_metadata: self.message_with_metadata,
         }
     }
 }
 
-/// A message bundle destined for another node.
-///
-/// During message pre-processing, a `MessageBundle` transitions to a `CheckedMessageBundle`.
-///
-/// Note that this is already signed.
+/// A signed message destined for another node.
 #[derive(Clone, Debug)]
-pub struct MessageBundle {
-    direct_message: SignedMessage<DirectMessage>,
-    echo_broadcast: SignedMessage<EchoBroadcast>,
-    normal_broadcast: SignedMessage<NormalBroadcast>,
+pub struct Message {
+    direct_message: SignedMessagePart<DirectMessage>,
+    echo_broadcast: SignedMessagePart<EchoBroadcast>,
+    normal_broadcast: SignedMessagePart<NormalBroadcast>,
 }
 
-impl MessageBundle {
+impl Message {
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn new<SP>(
         rng: &mut impl CryptoRngCore,
@@ -195,13 +191,13 @@ impl MessageBundle {
         session_id: &SessionId,
         round_id: RoundId,
         direct_message: DirectMessage,
-        echo_broadcast: SignedMessage<EchoBroadcast>,
-        normal_broadcast: SignedMessage<NormalBroadcast>,
+        echo_broadcast: SignedMessagePart<EchoBroadcast>,
+        normal_broadcast: SignedMessagePart<NormalBroadcast>,
     ) -> Result<Self, LocalError>
     where
         SP: SessionParameters,
     {
-        let direct_message = SignedMessage::new::<SP>(rng, signer, session_id, round_id, direct_message)?;
+        let direct_message = SignedMessagePart::new::<SP>(rng, signer, session_id, round_id, direct_message)?;
         Ok(Self {
             direct_message,
             echo_broadcast,
@@ -209,7 +205,7 @@ impl MessageBundle {
         })
     }
 
-    pub(crate) fn unify_metadata(self) -> Option<CheckedMessageBundle> {
+    pub(crate) fn unify_metadata(self) -> Option<CheckedMessage> {
         if self.echo_broadcast.metadata() != self.direct_message.metadata() {
             return None;
         }
@@ -219,7 +215,7 @@ impl MessageBundle {
         }
 
         let metadata = self.direct_message.message_with_metadata.metadata.clone();
-        Some(CheckedMessageBundle {
+        Some(CheckedMessage {
             metadata,
             direct_message: self.direct_message,
             echo_broadcast: self.echo_broadcast,
@@ -228,24 +224,24 @@ impl MessageBundle {
     }
 }
 
-/// A `CheckedMessageBundle` is like a [`MessageBundle`] but where we have checked that the metadata
+/// A `CheckedMessage` is like a [`Message`] but where we have checked that the metadata
 /// (i.e. SessionId and RoundId) from the Echo message (if any) matches with that of the
 /// [`DirectMessage`].
-/// `CheckedMessageBundle`s can transition to [`VerifiedMessageBundle`].
+/// `CheckedMessage`s can transition to [`VerifiedMessage`].
 #[derive(Clone, Debug)]
-pub(crate) struct CheckedMessageBundle {
+pub(crate) struct CheckedMessage {
     metadata: MessageMetadata,
-    direct_message: SignedMessage<DirectMessage>,
-    echo_broadcast: SignedMessage<EchoBroadcast>,
-    normal_broadcast: SignedMessage<NormalBroadcast>,
+    direct_message: SignedMessagePart<DirectMessage>,
+    echo_broadcast: SignedMessagePart<EchoBroadcast>,
+    normal_broadcast: SignedMessagePart<NormalBroadcast>,
 }
 
-impl CheckedMessageBundle {
+impl CheckedMessage {
     pub fn metadata(&self) -> &MessageMetadata {
         &self.metadata
     }
 
-    pub fn verify<SP>(self, verifier: &SP::Verifier) -> Result<VerifiedMessageBundle<SP>, MessageVerificationError>
+    pub fn verify<SP>(self, verifier: &SP::Verifier) -> Result<VerifiedMessage<SP>, MessageVerificationError>
     where
         SP: SessionParameters,
     {
@@ -253,7 +249,7 @@ impl CheckedMessageBundle {
         let echo_broadcast = self.echo_broadcast.verify::<SP>(verifier)?;
         let normal_broadcast = self.normal_broadcast.verify::<SP>(verifier)?;
 
-        Ok(VerifiedMessageBundle {
+        Ok(VerifiedMessage {
             from: verifier.clone(),
             metadata: self.metadata,
             direct_message,
@@ -263,20 +259,22 @@ impl CheckedMessageBundle {
     }
 }
 
-/// A `VerifiedMessageBundle` is the final evolution of a [`MessageBundle`]. At this point in the
-/// process, the [`DirectMessage`] and an eventual [`EchoBroadcast`] have been fully checked and the
-/// signature on the [`SignedMessage`] from the original [`MessageBundle`] successfully verified.
+// A `VerifiedMessage` is the final evolution of a [`Message`]. At this point in the
+// process, the [`DirectMessage`] and an eventual [`EchoBroadcast`] have been fully checked and the
+// signatures of message parts (direct, broadcast etc) from the original [`Message`] successfully verified.
+
+/// A [`Message`] that had its metadata and signatures verified.
 #[derive_where::derive_where(Debug)]
 #[derive(Clone)]
-pub struct VerifiedMessageBundle<SP: SessionParameters> {
+pub struct VerifiedMessage<SP: SessionParameters> {
     from: SP::Verifier,
     metadata: MessageMetadata,
-    direct_message: VerifiedMessage<DirectMessage>,
-    echo_broadcast: VerifiedMessage<EchoBroadcast>,
-    normal_broadcast: VerifiedMessage<NormalBroadcast>,
+    direct_message: VerifiedMessagePart<DirectMessage>,
+    echo_broadcast: VerifiedMessagePart<EchoBroadcast>,
+    normal_broadcast: VerifiedMessagePart<NormalBroadcast>,
 }
 
-impl<SP> VerifiedMessageBundle<SP>
+impl<SP> VerifiedMessage<SP>
 where
     SP: SessionParameters,
 {
@@ -300,14 +298,14 @@ where
         self.normal_broadcast.payload()
     }
 
-    /// Split the `VerifiedMessageBundle` into its signed constituent parts:
+    /// Split the `VerifiedMessage` into its signed constituent parts:
     /// the echo broadcast and the direct message.
     pub(crate) fn into_parts(
         self,
     ) -> (
-        SignedMessage<EchoBroadcast>,
-        SignedMessage<NormalBroadcast>,
-        SignedMessage<DirectMessage>,
+        SignedMessagePart<EchoBroadcast>,
+        SignedMessagePart<NormalBroadcast>,
+        SignedMessagePart<DirectMessage>,
     ) {
         let direct_message = self.direct_message.into_unverified();
         let echo_broadcast = self.echo_broadcast.into_unverified();

--- a/manul/src/session/session.rs
+++ b/manul/src/session/session.rs
@@ -16,7 +16,7 @@ use tracing::{debug, trace};
 use super::{
     echo::EchoRound,
     evidence::Evidence,
-    message::{MessageBundle, MessageVerificationError, SignedMessage, VerifiedMessageBundle},
+    message::{Message, MessageVerificationError, SignedMessagePart, VerifiedMessage},
     transcript::{SessionOutcome, SessionReport, Transcript},
     wire_format::WireFormat,
     LocalError, RemoteError,
@@ -114,8 +114,8 @@ pub struct Session<P: Protocol, SP: SessionParameters> {
     deserializer: Deserializer,
     round: Box<dyn ObjectSafeRound<SP::Verifier, Protocol = P>>,
     message_destinations: BTreeSet<SP::Verifier>,
-    echo_broadcast: SignedMessage<EchoBroadcast>,
-    normal_broadcast: SignedMessage<NormalBroadcast>,
+    echo_broadcast: SignedMessagePart<EchoBroadcast>,
+    normal_broadcast: SignedMessagePart<NormalBroadcast>,
     possible_next_rounds: BTreeSet<RoundId>,
     transcript: Transcript<P, SP>,
 }
@@ -130,7 +130,7 @@ pub enum RoundOutcome<P: Protocol, SP: SessionParameters> {
         /// The session object for the new round.
         session: Session<P, SP>,
         /// The messages intended for the new round cached during the previous round.
-        cached_messages: Vec<VerifiedMessageBundle<SP>>,
+        cached_messages: Vec<VerifiedMessage<SP>>,
     },
 }
 
@@ -181,10 +181,10 @@ where
         let verifier = signer.verifying_key();
 
         let echo = round.make_echo_broadcast(rng, &serializer)?;
-        let echo_broadcast = SignedMessage::new::<SP>(rng, &signer, &session_id, round.id(), echo)?;
+        let echo_broadcast = SignedMessagePart::new::<SP>(rng, &signer, &session_id, round.id(), echo)?;
 
         let normal = round.make_normal_broadcast(rng, &serializer)?;
-        let normal_broadcast = SignedMessage::new::<SP>(rng, &signer, &session_id, round.id(), normal)?;
+        let normal_broadcast = SignedMessagePart::new::<SP>(rng, &signer, &session_id, round.id(), normal)?;
 
         let message_destinations = round.message_destinations().clone();
 
@@ -231,12 +231,12 @@ where
         &self,
         rng: &mut impl CryptoRngCore,
         destination: &SP::Verifier,
-    ) -> Result<(MessageBundle, ProcessedArtifact<SP>), LocalError> {
+    ) -> Result<(Message, ProcessedArtifact<SP>), LocalError> {
         let (direct_message, artifact) =
             self.round
                 .make_direct_message_with_artifact(rng, &self.serializer, destination)?;
 
-        let bundle = MessageBundle::new::<SP>(
+        let message = Message::new::<SP>(
             rng,
             &self.signer,
             &self.session_id,
@@ -246,13 +246,12 @@ where
             self.normal_broadcast.clone(),
         )?;
 
-        Ok((
-            bundle,
-            ProcessedArtifact {
-                destination: destination.clone(),
-                artifact,
-            },
-        ))
+        let processed_artifact = ProcessedArtifact {
+            destination: destination.clone(),
+            artifact,
+        };
+
+        Ok((message, processed_artifact))
     }
 
     /// Adds the artifact from [`make_message`](`Self::make_message`) to the accumulator.
@@ -286,8 +285,8 @@ where
         &self,
         accum: &mut RoundAccumulator<P, SP>,
         from: &SP::Verifier,
-        message: MessageBundle,
-    ) -> Result<Option<VerifiedMessageBundle<SP>>, LocalError> {
+        message: Message,
+    ) -> Result<Option<VerifiedMessage<SP>>, LocalError> {
         // Quick preliminary checks, before we proceed with more expensive verification
         let key = self.verifier();
         if self.transcript.is_banned(from) || accum.is_banned(from) {
@@ -382,7 +381,7 @@ where
     pub fn process_message(
         &self,
         rng: &mut impl CryptoRngCore,
-        message: VerifiedMessageBundle<SP>,
+        message: VerifiedMessage<SP>,
     ) -> ProcessedMessage<P, SP> {
         let processed = self.round.receive_message(
             rng,
@@ -545,10 +544,10 @@ pub struct RoundAccumulator<P: Protocol, SP: SessionParameters> {
     processing: BTreeSet<SP::Verifier>,
     payloads: BTreeMap<SP::Verifier, Payload>,
     artifacts: BTreeMap<SP::Verifier, Artifact>,
-    cached: BTreeMap<SP::Verifier, BTreeMap<RoundId, VerifiedMessageBundle<SP>>>,
-    echo_broadcasts: BTreeMap<SP::Verifier, SignedMessage<EchoBroadcast>>,
-    normal_broadcasts: BTreeMap<SP::Verifier, SignedMessage<NormalBroadcast>>,
-    direct_messages: BTreeMap<SP::Verifier, SignedMessage<DirectMessage>>,
+    cached: BTreeMap<SP::Verifier, BTreeMap<RoundId, VerifiedMessage<SP>>>,
+    echo_broadcasts: BTreeMap<SP::Verifier, SignedMessagePart<EchoBroadcast>>,
+    normal_broadcasts: BTreeMap<SP::Verifier, SignedMessagePart<NormalBroadcast>>,
+    direct_messages: BTreeMap<SP::Verifier, SignedMessagePart<DirectMessage>>,
     provable_errors: BTreeMap<SP::Verifier, Evidence<P, SP>>,
     unprovable_errors: BTreeMap<SP::Verifier, RemoteError>,
 }
@@ -626,7 +625,7 @@ where
         }
     }
 
-    fn mark_processing(&mut self, message: &VerifiedMessageBundle<SP>) -> Result<(), LocalError> {
+    fn mark_processing(&mut self, message: &VerifiedMessage<SP>) -> Result<(), LocalError> {
         if !self.processing.insert(message.from().clone()) {
             Err(LocalError::new(format!(
                 "A message from {:?} is already marked as being processed",
@@ -733,7 +732,7 @@ where
         }
     }
 
-    fn cache_message(&mut self, message: VerifiedMessageBundle<SP>) -> Result<(), LocalError> {
+    fn cache_message(&mut self, message: VerifiedMessage<SP>) -> Result<(), LocalError> {
         let from = message.from().clone();
         let round_id = message.metadata().round_id();
         let cached = self.cached.entry(from.clone()).or_default();
@@ -755,14 +754,14 @@ pub struct ProcessedArtifact<SP: SessionParameters> {
 
 #[derive(Debug)]
 pub struct ProcessedMessage<P: Protocol, SP: SessionParameters> {
-    message: VerifiedMessageBundle<SP>,
+    message: VerifiedMessage<SP>,
     processed: Result<Payload, ReceiveError<SP::Verifier, P>>,
 }
 
 fn filter_messages<SP: SessionParameters>(
-    messages: BTreeMap<SP::Verifier, BTreeMap<RoundId, VerifiedMessageBundle<SP>>>,
+    messages: BTreeMap<SP::Verifier, BTreeMap<RoundId, VerifiedMessage<SP>>>,
     round_id: RoundId,
-) -> Vec<VerifiedMessageBundle<SP>> {
+) -> Vec<VerifiedMessage<SP>> {
     messages
         .into_values()
         .filter_map(|mut messages| messages.remove(&round_id))
@@ -776,7 +775,7 @@ mod tests {
     use impls::impls;
     use serde::{Deserialize, Serialize};
 
-    use super::{MessageBundle, ProcessedArtifact, ProcessedMessage, Session, VerifiedMessageBundle};
+    use super::{Message, ProcessedArtifact, ProcessedMessage, Session, VerifiedMessage};
     use crate::{
         protocol::{
             Deserializer, DirectMessage, EchoBroadcast, NormalBroadcast, Protocol, ProtocolError,
@@ -836,9 +835,9 @@ mod tests {
         assert!(impls!(Session<DummyProtocol, SP>: Sync));
 
         // These objects are sent to/from message processing tasks
-        assert!(impls!(MessageBundle: Send));
+        assert!(impls!(Message: Send));
         assert!(impls!(ProcessedArtifact<SP>: Send));
-        assert!(impls!(VerifiedMessageBundle<SP>: Send));
+        assert!(impls!(VerifiedMessage<SP>: Send));
         assert!(impls!(ProcessedMessage<DummyProtocol, SP>: Send));
     }
 }

--- a/manul/src/session/transcript.rs
+++ b/manul/src/session/transcript.rs
@@ -4,14 +4,14 @@ use alloc::{
 };
 use core::fmt::Debug;
 
-use super::{evidence::Evidence, message::SignedMessage, session::SessionParameters, LocalError, RemoteError};
+use super::{evidence::Evidence, message::SignedMessagePart, session::SessionParameters, LocalError, RemoteError};
 use crate::protocol::{DirectMessage, EchoBroadcast, NormalBroadcast, Protocol, RoundId};
 
 #[derive(Debug)]
 pub(crate) struct Transcript<P: Protocol, SP: SessionParameters> {
-    echo_broadcasts: BTreeMap<RoundId, BTreeMap<SP::Verifier, SignedMessage<EchoBroadcast>>>,
-    normal_broadcasts: BTreeMap<RoundId, BTreeMap<SP::Verifier, SignedMessage<NormalBroadcast>>>,
-    direct_messages: BTreeMap<RoundId, BTreeMap<SP::Verifier, SignedMessage<DirectMessage>>>,
+    echo_broadcasts: BTreeMap<RoundId, BTreeMap<SP::Verifier, SignedMessagePart<EchoBroadcast>>>,
+    normal_broadcasts: BTreeMap<RoundId, BTreeMap<SP::Verifier, SignedMessagePart<NormalBroadcast>>>,
+    direct_messages: BTreeMap<RoundId, BTreeMap<SP::Verifier, SignedMessagePart<DirectMessage>>>,
     provable_errors: BTreeMap<SP::Verifier, Evidence<P, SP>>,
     unprovable_errors: BTreeMap<SP::Verifier, RemoteError>,
     missing_messages: BTreeMap<RoundId, BTreeSet<SP::Verifier>>,
@@ -37,9 +37,9 @@ where
     pub fn update(
         self,
         round_id: RoundId,
-        echo_broadcasts: BTreeMap<SP::Verifier, SignedMessage<EchoBroadcast>>,
-        normal_broadcasts: BTreeMap<SP::Verifier, SignedMessage<NormalBroadcast>>,
-        direct_messages: BTreeMap<SP::Verifier, SignedMessage<DirectMessage>>,
+        echo_broadcasts: BTreeMap<SP::Verifier, SignedMessagePart<EchoBroadcast>>,
+        normal_broadcasts: BTreeMap<SP::Verifier, SignedMessagePart<NormalBroadcast>>,
+        direct_messages: BTreeMap<SP::Verifier, SignedMessagePart<DirectMessage>>,
         provable_errors: BTreeMap<SP::Verifier, Evidence<P, SP>>,
         unprovable_errors: BTreeMap<SP::Verifier, RemoteError>,
         missing_messages: BTreeSet<SP::Verifier>,
@@ -116,7 +116,7 @@ where
         &self,
         round_id: RoundId,
         from: &SP::Verifier,
-    ) -> Result<SignedMessage<EchoBroadcast>, LocalError> {
+    ) -> Result<SignedMessagePart<EchoBroadcast>, LocalError> {
         self.echo_broadcasts
             .get(&round_id)
             .ok_or_else(|| LocalError::new(format!("No echo broadcasts registered for {round_id:?}")))?
@@ -129,7 +129,7 @@ where
         &self,
         round_id: RoundId,
         from: &SP::Verifier,
-    ) -> Result<SignedMessage<NormalBroadcast>, LocalError> {
+    ) -> Result<SignedMessagePart<NormalBroadcast>, LocalError> {
         self.normal_broadcasts
             .get(&round_id)
             .ok_or_else(|| LocalError::new(format!("No normal broadcasts registered for {round_id:?}")))?
@@ -142,7 +142,7 @@ where
         &self,
         round_id: RoundId,
         from: &SP::Verifier,
-    ) -> Result<SignedMessage<DirectMessage>, LocalError> {
+    ) -> Result<SignedMessagePart<DirectMessage>, LocalError> {
         self.direct_messages
             .get(&round_id)
             .ok_or_else(|| LocalError::new(format!("No direct messages registered for {round_id:?}")))?
@@ -158,7 +158,7 @@ where
     pub fn echo_broadcasts(
         &self,
         round_id: RoundId,
-    ) -> Result<BTreeMap<SP::Verifier, SignedMessage<EchoBroadcast>>, LocalError> {
+    ) -> Result<BTreeMap<SP::Verifier, SignedMessagePart<EchoBroadcast>>, LocalError> {
         self.echo_broadcasts
             .get(&round_id)
             .cloned()

--- a/manul/src/testing/run_sync.rs
+++ b/manul/src/testing/run_sync.rs
@@ -24,7 +24,7 @@ enum State<P: Protocol, SP: SessionParameters> {
 struct RoundMessage<SP: SessionParameters> {
     from: SP::Verifier,
     to: SP::Verifier,
-    message: Message,
+    message: Message<SP::Verifier>,
 }
 
 #[allow(clippy::type_complexity)]


### PR DESCRIPTION
- re-export `digest` module from `session` (should have been done when `Digest` was added to `SessionParameters`)
- rename `*MessageBundle` to `*Message`, and `Signed`/`VerifiedMessage` to `Signed`/`VerifiedMessagePart`. Fixes #42
- make `VerifiedMessage` generic over `Verifier` and not the whole `SessionParameters`
- add `Message::destination()` to simplify the user's life a bit.