### PR TITLE
Separate user interrupt and terminating due to errors in `SessionOutome`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Serialization format is a part of `SessionParameters` now; `Round` and `Protocol` methods receive dynamic serializers/deserializers. ([#33])
 - Renamed `(Verified)MessageBundle` to `(Verified)Message`. Both are now generic over `Verifier`. ([#56])
 - `Session::preprocess_message()` now returns a `PreprocessOutcome` instead of just an `Option`. ([#57])
+- `Session::terminate_due_to_errors()` replaces `terminate()`; `terminate()` now signals user interrupt. ([#58])
 
 
 ### Added
@@ -41,6 +42,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#47]: https://github.com/entropyxyz/manul/pull/47
 [#56]: https://github.com/entropyxyz/manul/pull/56
 [#57]: https://github.com/entropyxyz/manul/pull/57
+[#58]: https://github.com/entropyxyz/manul/pull/58
 
 
 ## [0.0.1] - 2024-10-12

--- a/examples/tests/async_runner.rs
+++ b/examples/tests/async_runner.rs
@@ -112,7 +112,7 @@ where
                 // Terminating.
                 CanFinalize::Never => {
                     tracing::warn!("{key:?}: This session cannot ever be finalized. Terminating.");
-                    return session.terminate(accum);
+                    return session.terminate_due_to_errors(accum);
                 }
             }
 

--- a/manul/src/session/transcript.rs
+++ b/manul/src/session/transcript.rs
@@ -174,10 +174,13 @@ pub enum SessionOutcome<P: Protocol> {
     /// The execution stalled because of an unattributable error,
     /// but the protocol created a proof that this node performed its duties correctly.
     ///
-    /// This protocol is supposed to be passed to a third party for adjudication.
+    /// This proof is supposed to be passed to a third party for adjudication,
+    /// along with the proofs from the other nodes.
     StalledWithProof(P::CorrectnessProof),
     /// The execution stalled because not enough messages were received to finalize the round.
     NotEnoughMessages,
+    /// The execution was terminated by the user.
+    Terminated,
 }
 
 /// The report of a session execution.

--- a/manul/src/testing/run_sync.rs
+++ b/manul/src/testing/run_sync.rs
@@ -68,7 +68,7 @@ where
                 }
             }
             CanFinalize::NotYet => break State::InProgress { session, accum },
-            CanFinalize::Never => break State::Finished(session.terminate(accum)?),
+            CanFinalize::Never => break State::Finished(session.terminate_due_to_errors(accum)?),
         }
 
         let destinations = session.message_destinations();


### PR DESCRIPTION
Fixes #19

`terminate_due_to_errors()` is kind of an awkward name, but I can't come up with anything better now.

Maybe we'll be able to select the reason automatically when #15 is fixed.