### PR TITLE
Logic fixes for rounds with partial echo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -494,6 +494,7 @@ dependencies = [
  "signature",
  "tinyvec",
  "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,1 +1,0 @@
-allow-unwrap-in-tests = true

--- a/manul/Cargo.toml
+++ b/manul/Cargo.toml
@@ -29,12 +29,14 @@ serde_json = { version = "1", default-features = false, features = ["alloc"], op
 
 [dev-dependencies]
 impls = "1"
+rand_core = { version = "0.6.4", default-features = false, features = ["getrandom"] }
 rand = { version = "0.8", default-features = false }
 serde_asn1_der = "0.8"
 criterion = "0.5"
 serde-persistent-deserializer = "0.3"
 postcard = { version = "1", default-features = false, features = ["alloc"] }
 serde_json = { version = "1", default-features = false, features = ["alloc"] }
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 [features]
 testing = ["rand", "postcard", "serde_json", "serde-persistent-deserializer"]

--- a/manul/src/combinators/chain.rs
+++ b/manul/src/combinators/chain.rs
@@ -382,6 +382,20 @@ where
         }
     }
 
+    fn expecting_messages_from(&self) -> &BTreeSet<Id> {
+        match &self.state {
+            ChainState::Protocol1 { round, .. } => round.as_ref().expecting_messages_from(),
+            ChainState::Protocol2(round) => round.as_ref().expecting_messages_from(),
+        }
+    }
+
+    fn echo_round_participation(&self) -> EchoRoundParticipation<Id> {
+        match &self.state {
+            ChainState::Protocol1 { round, .. } => round.as_ref().echo_round_participation(),
+            ChainState::Protocol2(round) => round.as_ref().echo_round_participation(),
+        }
+    }
+
     fn make_direct_message(
         &self,
         rng: &mut dyn CryptoRngCore,
@@ -512,13 +526,6 @@ where
                     ChainedCorrectnessProof::from_protocol2(proof),
                 )),
             },
-        }
-    }
-
-    fn expecting_messages_from(&self) -> &BTreeSet<Id> {
-        match &self.state {
-            ChainState::Protocol1 { round, .. } => round.as_ref().expecting_messages_from(),
-            ChainState::Protocol2(round) => round.as_ref().expecting_messages_from(),
         }
     }
 }

--- a/manul/src/combinators/misbehave.rs
+++ b/manul/src/combinators/misbehave.rs
@@ -29,8 +29,9 @@ use core::fmt::Debug;
 use rand_core::CryptoRngCore;
 
 use crate::protocol::{
-    Artifact, BoxedRng, BoxedRound, Deserializer, DirectMessage, EchoBroadcast, EntryPoint, FinalizeError,
-    FinalizeOutcome, LocalError, NormalBroadcast, ObjectSafeRound, PartyId, Payload, ReceiveError, RoundId, Serializer,
+    Artifact, BoxedRng, BoxedRound, Deserializer, DirectMessage, EchoBroadcast, EchoRoundParticipation, EntryPoint,
+    FinalizeError, FinalizeOutcome, LocalError, NormalBroadcast, ObjectSafeRound, PartyId, Payload, ReceiveError,
+    RoundId, Serializer,
 };
 
 /// A trait describing required properties for a behavior type.
@@ -173,6 +174,14 @@ where
         self.round.as_ref().message_destinations()
     }
 
+    fn expecting_messages_from(&self) -> &BTreeSet<Id> {
+        self.round.as_ref().expecting_messages_from()
+    }
+
+    fn echo_round_participation(&self) -> EchoRoundParticipation<Id> {
+        self.round.as_ref().echo_round_participation()
+    }
+
     fn make_direct_message(
         &self,
         rng: &mut dyn CryptoRngCore,
@@ -283,9 +292,5 @@ where
             ))),
             Err(err) => Err(err),
         }
-    }
-
-    fn expecting_messages_from(&self) -> &BTreeSet<Id> {
-        self.round.as_ref().expecting_messages_from()
     }
 }

--- a/manul/src/lib.rs
+++ b/manul/src/lib.rs
@@ -3,8 +3,6 @@
 #![doc = include_str!("../../README.md")]
 #![warn(
     clippy::mod_module_files,
-    clippy::unwrap_used,
-    clippy::indexing_slicing,
     missing_docs,
     missing_copy_implementations,
     rust_2018_idioms,
@@ -13,6 +11,7 @@
     unused_qualifications,
     missing_debug_implementations
 )]
+#![cfg_attr(not(test), warn(clippy::unwrap_used, clippy::indexing_slicing,))]
 
 extern crate alloc;
 

--- a/manul/src/lib.rs
+++ b/manul/src/lib.rs
@@ -22,3 +22,6 @@ pub(crate) mod utils;
 
 #[cfg(any(test, feature = "testing"))]
 pub mod testing;
+
+#[cfg(test)]
+mod tests;

--- a/manul/src/protocol.rs
+++ b/manul/src/protocol.rs
@@ -24,7 +24,8 @@ pub use errors::{
 pub use message::{DirectMessage, EchoBroadcast, NormalBroadcast, ProtocolMessagePart};
 pub use object_safe::BoxedRound;
 pub use round::{
-    Artifact, CorrectnessProof, EntryPoint, FinalizeOutcome, PartyId, Payload, Protocol, ProtocolError, Round, RoundId,
+    Artifact, CorrectnessProof, EchoRoundParticipation, EntryPoint, FinalizeOutcome, PartyId, Payload, Protocol,
+    ProtocolError, Round, RoundId,
 };
 pub use serialization::{Deserializer, Serializer};
 

--- a/manul/src/tests.rs
+++ b/manul/src/tests.rs
@@ -1,0 +1,1 @@
+mod partial_echo;

--- a/manul/src/tests/partial_echo.rs
+++ b/manul/src/tests/partial_echo.rs
@@ -1,0 +1,232 @@
+use alloc::{
+    collections::{BTreeMap, BTreeSet},
+    format,
+    string::String,
+    vec,
+    vec::Vec,
+};
+use core::fmt::Debug;
+
+use rand_core::{CryptoRngCore, OsRng};
+use serde::{Deserialize, Serialize};
+use tracing_subscriber::EnvFilter;
+
+use crate::{
+    protocol::*,
+    session::{signature::Keypair, SessionOutcome},
+    testing::{run_sync, BinaryFormat, TestSessionParams, TestSigner, TestVerifier},
+};
+
+#[derive(Debug)]
+struct PartialEchoProtocol;
+
+impl Protocol for PartialEchoProtocol {
+    type Result = ();
+    type ProtocolError = PartialEchoProtocolError;
+    type CorrectnessProof = ();
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct PartialEchoProtocolError;
+
+impl ProtocolError for PartialEchoProtocolError {
+    fn description(&self) -> String {
+        format!("{:?}", self)
+    }
+
+    fn verify_messages_constitute_error(
+        &self,
+        _deserializer: &Deserializer,
+        _echo_broadcast: &EchoBroadcast,
+        _normal_broadcast: &NormalBroadcast,
+        _direct_message: &DirectMessage,
+        _echo_broadcasts: &BTreeMap<RoundId, EchoBroadcast>,
+        _normal_broadcasts: &BTreeMap<RoundId, NormalBroadcast>,
+        _direct_messages: &BTreeMap<RoundId, DirectMessage>,
+        _combined_echos: &BTreeMap<RoundId, Vec<EchoBroadcast>>,
+    ) -> Result<(), ProtocolValidationError> {
+        unimplemented!()
+    }
+}
+
+#[derive(Debug, Clone)]
+struct Inputs<Id> {
+    message_destinations: Vec<Id>,
+    expecting_messages_from: Vec<Id>,
+    echo_round_participation: EchoRoundParticipation<Id>,
+}
+
+#[derive(Debug)]
+struct Round1<Id> {
+    id: Id,
+    message_destinations: BTreeSet<Id>,
+    expecting_messages_from: BTreeSet<Id>,
+    echo_round_participation: EchoRoundParticipation<Id>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct Round1Echo<Id> {
+    sender: Id,
+}
+
+impl<Id: PartyId + Serialize + for<'de> Deserialize<'de>> EntryPoint<Id> for Round1<Id> {
+    type Inputs = Inputs<Id>;
+    type Protocol = PartialEchoProtocol;
+    fn new(
+        _rng: &mut impl CryptoRngCore,
+        _shared_randomness: &[u8],
+        id: Id,
+        inputs: Self::Inputs,
+    ) -> Result<BoxedRound<Id, Self::Protocol>, LocalError> {
+        let message_destinations = BTreeSet::from_iter(inputs.message_destinations);
+        let expecting_messages_from = BTreeSet::from_iter(inputs.expecting_messages_from);
+        Ok(BoxedRound::new_dynamic(Self {
+            id,
+            message_destinations,
+            expecting_messages_from,
+            echo_round_participation: inputs.echo_round_participation,
+        }))
+    }
+}
+
+impl<Id: PartyId + Serialize + for<'de> Deserialize<'de>> Round<Id> for Round1<Id> {
+    type Protocol = PartialEchoProtocol;
+
+    fn id(&self) -> RoundId {
+        RoundId::new(1)
+    }
+
+    fn possible_next_rounds(&self) -> BTreeSet<RoundId> {
+        BTreeSet::new()
+    }
+
+    fn message_destinations(&self) -> &BTreeSet<Id> {
+        &self.message_destinations
+    }
+
+    fn expecting_messages_from(&self) -> &BTreeSet<Id> {
+        &self.expecting_messages_from
+    }
+
+    fn echo_round_participation(&self) -> EchoRoundParticipation<Id> {
+        self.echo_round_participation.clone()
+    }
+
+    fn make_echo_broadcast(
+        &self,
+        _rng: &mut impl CryptoRngCore,
+        serializer: &Serializer,
+    ) -> Result<EchoBroadcast, LocalError> {
+        if self.message_destinations.is_empty() {
+            Ok(EchoBroadcast::none())
+        } else {
+            EchoBroadcast::new(
+                serializer,
+                Round1Echo {
+                    sender: self.id.clone(),
+                },
+            )
+        }
+    }
+
+    fn receive_message(
+        &self,
+        _rng: &mut impl CryptoRngCore,
+        deserializer: &Deserializer,
+        from: &Id,
+        echo_broadcast: EchoBroadcast,
+        normal_broadcast: NormalBroadcast,
+        direct_message: DirectMessage,
+    ) -> Result<Payload, ReceiveError<Id, Self::Protocol>> {
+        normal_broadcast.assert_is_none()?;
+        direct_message.assert_is_none()?;
+
+        if self.expecting_messages_from.is_empty() {
+            echo_broadcast.assert_is_none()?;
+        } else {
+            let echo = echo_broadcast.deserialize::<Round1Echo<Id>>(deserializer)?;
+            assert_eq!(&echo.sender, from);
+            assert!(self.expecting_messages_from.contains(from));
+        }
+
+        Ok(Payload::new(()))
+    }
+
+    fn finalize(
+        self,
+        _rng: &mut impl CryptoRngCore,
+        _payloads: BTreeMap<Id, Payload>,
+        _artifacts: BTreeMap<Id, Artifact>,
+    ) -> Result<FinalizeOutcome<Id, Self::Protocol>, FinalizeError<Self::Protocol>> {
+        Ok(FinalizeOutcome::Result(()))
+    }
+}
+
+#[test]
+fn partial_echo() {
+    let signers = (0..5).map(TestSigner::new).collect::<Vec<_>>();
+    let ids = signers.iter().map(|signer| signer.verifying_key()).collect::<Vec<_>>();
+
+    // Nodes 0, 1 send an echo broadcast to nodes 1, 2, 3
+    // The echo round happens between the nodes 1, 2, 3
+    // Node 0 only sends the broadcasts, but doesn't receive any, so it skips the echo round
+    // Node 4 doesn't send or receive any broadcasts, so it skips the echo round
+
+    let node0 = (
+        signers[0],
+        Inputs {
+            message_destinations: [ids[1], ids[2], ids[3]].into(),
+            expecting_messages_from: [].into(),
+            echo_round_participation: EchoRoundParticipation::Send,
+        },
+    );
+    let node1 = (
+        signers[1],
+        Inputs {
+            message_destinations: [ids[2], ids[3]].into(),
+            expecting_messages_from: [ids[0]].into(),
+            echo_round_participation: EchoRoundParticipation::Default,
+        },
+    );
+    let node2 = (
+        signers[2],
+        Inputs {
+            message_destinations: [].into(),
+            expecting_messages_from: [ids[0], ids[1]].into(),
+            echo_round_participation: EchoRoundParticipation::Receive {
+                echo_targets: BTreeSet::from([ids[1], ids[3]]),
+            },
+        },
+    );
+    let node3 = (
+        signers[3],
+        Inputs {
+            message_destinations: [].into(),
+            expecting_messages_from: [ids[0], ids[1]].into(),
+            echo_round_participation: EchoRoundParticipation::Receive {
+                echo_targets: BTreeSet::from([ids[1], ids[2]]),
+            },
+        },
+    );
+    let node4 = (
+        signers[4],
+        Inputs {
+            message_destinations: [].into(),
+            expecting_messages_from: [].into(),
+            echo_round_participation: EchoRoundParticipation::<TestVerifier>::Default,
+        },
+    );
+
+    let inputs = vec![node0, node1, node2, node3, node4];
+
+    let my_subscriber = tracing_subscriber::fmt()
+        .with_env_filter(EnvFilter::from_default_env())
+        .finish();
+    let reports = tracing::subscriber::with_default(my_subscriber, || {
+        run_sync::<Round1<TestVerifier>, TestSessionParams<BinaryFormat>>(&mut OsRng, inputs).unwrap()
+    });
+
+    for (_id, report) in reports {
+        assert!(matches!(report.outcome, SessionOutcome::Result(_)));
+    }
+}


### PR DESCRIPTION
Fixes #21

Imagine the following round configuration (which is possible during KeyResharing from `synedrion`):
- node 0 sends an echo-broadcast to [1, 2, 3]
- node 1 sends an echo-broadcast to [2, 3]
- nodes 2 and 3 do not send echo-broadcasts

After we received the initial broadcasts, we want an echo round where the nodes 1, 2, 3 echo received messages to each other. That is:
- node 0 does not send or receive anything
- node 1 sends the broadcasts from [0] to 2 and 3, and expects [0, 1] from 2 and 3
- node 2 sends the broadcasts from [0, 1] to 1 and 3, and expects [0] from 1 and [0, 1] from 3
- node 3 sends the broadcasts from [0, 1] to 1 and 2, and expects [0] from 1 and [0, 1] from 2

(note that node 1 does not send its broadcast the second time; that would be pointless)

This requires adding another method to `Round` specifying the exact behavior of the node, since this information cannot be obtained from existing methods. This PR introduces `Round::echo_round_participation()` and `EchoRoundParticipation` enum. 

In most cases we can use the blanket implementation returning `EchoRoundParticipation`, which means that the node either sends and receives echo messages, or does neither. This means that we can deduce the properties of the echo round from `Round::message_destinations()` and `Round::expecting_messages_from()`. The case where the node only sends echo messages (node 0), we don't need any additional info other than this fact. For the case where the node only receives echo messages (node 3), it needs additional info specifying which nodes actually participate in the echo round.

*Edit:* another possible API here is to get rid of `EchoRoundParticipation` enum and instead have a method returning `Option<BTreeSet<Id>>`. `None` would cover both `Default` and `Send`, and we will distinguish between them by checking if `expecting_messages_from()` is empty or not. Would that work?