### PR TITLE
Stateful entry points

### DIFF
--- a/examples/src/simple.rs
+++ b/examples/src/simple.rs
@@ -324,6 +324,10 @@ impl<Id: PartyId> Round<Id> for Round2<Id> {
         BTreeSet::new()
     }
 
+    fn may_produce_result(&self) -> bool {
+        true
+    }
+
     fn message_destinations(&self) -> &BTreeSet<Id> {
         &self.context.other_ids
     }

--- a/examples/src/simple.rs
+++ b/examples/src/simple.rs
@@ -10,6 +10,7 @@ use rand_core::CryptoRngCore;
 use serde::{Deserialize, Serialize};
 use tracing::debug;
 
+#[derive(Debug)]
 pub struct SimpleProtocol;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -111,11 +112,6 @@ impl Protocol for SimpleProtocol {
     }
 }
 
-#[derive(Debug, Clone)]
-pub struct Inputs<Id> {
-    pub all_ids: BTreeSet<Id>,
-}
-
 #[derive(Debug)]
 pub(crate) struct Context<Id> {
     pub(crate) id: Id,
@@ -149,30 +145,40 @@ struct Round1Payload {
     x: u8,
 }
 
-impl<Id: PartyId> EntryPoint<Id> for Round1<Id> {
-    type Inputs = Inputs<Id>;
+#[derive(Debug, Clone)]
+pub struct SimpleProtocolEntryPoint<Id> {
+    all_ids: BTreeSet<Id>,
+}
+
+impl<Id: PartyId> SimpleProtocolEntryPoint<Id> {
+    pub fn new(all_ids: BTreeSet<Id>) -> Self {
+        Self { all_ids }
+    }
+}
+
+impl<Id: PartyId> EntryPoint<Id> for SimpleProtocolEntryPoint<Id> {
     type Protocol = SimpleProtocol;
-    fn new(
+    fn make_round(
+        self,
         _rng: &mut impl CryptoRngCore,
         _shared_randomness: &[u8],
-        id: Id,
-        inputs: Self::Inputs,
+        id: &Id,
     ) -> Result<BoxedRound<Id, Self::Protocol>, LocalError> {
         // Just some numbers associated with IDs to use in the dummy protocol.
         // They will be the same on each node since IDs are ordered.
-        let ids_to_positions = inputs
+        let ids_to_positions = self
             .all_ids
             .iter()
             .enumerate()
             .map(|(idx, id)| (id.clone(), idx as u8))
             .collect::<BTreeMap<_, _>>();
 
-        let mut ids = inputs.all_ids;
-        ids.remove(&id);
+        let mut ids = self.all_ids;
+        ids.remove(id);
 
-        Ok(BoxedRound::new_dynamic(Self {
+        Ok(BoxedRound::new_dynamic(Round1 {
             context: Context {
-                id,
+                id: id.clone(),
                 other_ids: ids,
                 ids_to_positions,
             },
@@ -401,12 +407,12 @@ mod tests {
 
     use manul::{
         session::{signature::Keypair, SessionOutcome},
-        testing::{run_sync, BinaryFormat, TestSessionParams, TestSigner, TestVerifier},
+        testing::{run_sync, BinaryFormat, TestSessionParams, TestSigner},
     };
     use rand_core::OsRng;
     use tracing_subscriber::EnvFilter;
 
-    use super::{Inputs, Round1};
+    use super::SimpleProtocolEntryPoint;
 
     #[test]
     fn round() {
@@ -415,23 +421,16 @@ mod tests {
             .iter()
             .map(|signer| signer.verifying_key())
             .collect::<BTreeSet<_>>();
-        let inputs = signers
+        let entry_points = signers
             .into_iter()
-            .map(|signer| {
-                (
-                    signer,
-                    Inputs {
-                        all_ids: all_ids.clone(),
-                    },
-                )
-            })
+            .map(|signer| (signer, SimpleProtocolEntryPoint::new(all_ids.clone())))
             .collect::<Vec<_>>();
 
         let my_subscriber = tracing_subscriber::fmt()
             .with_env_filter(EnvFilter::from_default_env())
             .finish();
         let reports = tracing::subscriber::with_default(my_subscriber, || {
-            run_sync::<Round1<TestVerifier>, TestSessionParams<BinaryFormat>>(&mut OsRng, inputs).unwrap()
+            run_sync::<_, TestSessionParams<BinaryFormat>>(&mut OsRng, entry_points).unwrap()
         });
 
         for (_id, report) in reports {

--- a/examples/src/simple_chain.rs
+++ b/examples/src/simple_chain.rs
@@ -1,37 +1,69 @@
+use alloc::collections::BTreeSet;
 use core::fmt::Debug;
 
 use manul::{
-    combinators::chain::{Chained, ChainedEntryPoint},
-    protocol::PartyId,
+    combinators::{
+        chain::{Chain, ChainedJoin, ChainedProtocol, ChainedSplit},
+        CombinatorEntryPoint,
+    },
+    protocol::{PartyId, Protocol},
 };
 
-use super::simple::{Inputs, Round1};
+use super::simple::{SimpleProtocol, SimpleProtocolEntryPoint};
 
-pub struct ChainedSimple;
+/// A protocol that runs the [`SimpleProtocol`] twice, in sequence.
+/// Illustrates the chain protocol combinator.
+#[derive(Debug)]
+pub struct DoubleSimpleProtocol;
+
+impl ChainedProtocol for DoubleSimpleProtocol {
+    type Protocol1 = SimpleProtocol;
+    type Protocol2 = SimpleProtocol;
+}
+
+pub struct DoubleSimpleEntryPoint<Id> {
+    all_ids: BTreeSet<Id>,
+}
+
+impl<Id: PartyId> DoubleSimpleEntryPoint<Id> {
+    pub fn new(all_ids: BTreeSet<Id>) -> Self {
+        Self { all_ids }
+    }
+}
+
+impl<Id> CombinatorEntryPoint for DoubleSimpleEntryPoint<Id> {
+    type Combinator = Chain;
+}
+
+impl<Id> ChainedSplit<Id> for DoubleSimpleEntryPoint<Id>
+where
+    Id: PartyId,
+{
+    type Protocol = DoubleSimpleProtocol;
+    type EntryPoint = SimpleProtocolEntryPoint<Id>;
+    fn make_entry_point1(self) -> (Self::EntryPoint, impl ChainedJoin<Id, Protocol = Self::Protocol>) {
+        (
+            SimpleProtocolEntryPoint::new(self.all_ids.clone()),
+            DoubleSimpleProtocolTransition { all_ids: self.all_ids },
+        )
+    }
+}
 
 #[derive(Debug)]
-pub struct NewInputs<Id>(Inputs<Id>);
+struct DoubleSimpleProtocolTransition<Id> {
+    all_ids: BTreeSet<Id>,
+}
 
-impl<'a, Id: PartyId> From<&'a NewInputs<Id>> for Inputs<Id> {
-    fn from(source: &'a NewInputs<Id>) -> Self {
-        source.0.clone()
+impl<Id> ChainedJoin<Id> for DoubleSimpleProtocolTransition<Id>
+where
+    Id: PartyId,
+{
+    type Protocol = DoubleSimpleProtocol;
+    type EntryPoint = SimpleProtocolEntryPoint<Id>;
+    fn make_entry_point2(self, _result: <SimpleProtocol as Protocol>::Result) -> Self::EntryPoint {
+        SimpleProtocolEntryPoint::new(self.all_ids)
     }
 }
-
-impl<Id: PartyId> From<(NewInputs<Id>, u8)> for Inputs<Id> {
-    fn from(source: (NewInputs<Id>, u8)) -> Self {
-        let (inputs, _result) = source;
-        inputs.0
-    }
-}
-
-impl<Id: PartyId> Chained<Id> for ChainedSimple {
-    type Inputs = NewInputs<Id>;
-    type EntryPoint1 = Round1<Id>;
-    type EntryPoint2 = Round1<Id>;
-}
-
-pub type DoubleSimpleEntryPoint<Id> = ChainedEntryPoint<Id, ChainedSimple>;
 
 #[cfg(test)]
 mod tests {
@@ -39,13 +71,12 @@ mod tests {
 
     use manul::{
         session::{signature::Keypair, SessionOutcome},
-        testing::{run_sync, BinaryFormat, TestSessionParams, TestSigner, TestVerifier},
+        testing::{run_sync, BinaryFormat, TestSessionParams, TestSigner},
     };
     use rand_core::OsRng;
     use tracing_subscriber::EnvFilter;
 
-    use super::{DoubleSimpleEntryPoint, NewInputs};
-    use crate::simple::Inputs;
+    use super::DoubleSimpleEntryPoint;
 
     #[test]
     fn round() {
@@ -54,24 +85,16 @@ mod tests {
             .iter()
             .map(|signer| signer.verifying_key())
             .collect::<BTreeSet<_>>();
-        let inputs = signers
+        let entry_points = signers
             .into_iter()
-            .map(|signer| {
-                (
-                    signer,
-                    NewInputs(Inputs {
-                        all_ids: all_ids.clone(),
-                    }),
-                )
-            })
+            .map(|signer| (signer, DoubleSimpleEntryPoint::new(all_ids.clone())))
             .collect::<Vec<_>>();
 
         let my_subscriber = tracing_subscriber::fmt()
             .with_env_filter(EnvFilter::from_default_env())
             .finish();
         let reports = tracing::subscriber::with_default(my_subscriber, || {
-            run_sync::<DoubleSimpleEntryPoint<TestVerifier>, TestSessionParams<BinaryFormat>>(&mut OsRng, inputs)
-                .unwrap()
+            run_sync::<_, TestSessionParams<BinaryFormat>>(&mut OsRng, entry_points).unwrap()
         });
 
         for (_id, report) in reports {

--- a/examples/src/simple_malicious.rs
+++ b/examples/src/simple_malicious.rs
@@ -2,18 +2,18 @@ use alloc::collections::BTreeSet;
 use core::fmt::Debug;
 
 use manul::{
-    combinators::misbehave::{Misbehaving, MisbehavingEntryPoint, MisbehavingInputs},
+    combinators::misbehave::{Misbehaving, MisbehavingEntryPoint},
     protocol::{
         Artifact, BoxedRound, Deserializer, DirectMessage, EntryPoint, LocalError, PartyId, ProtocolMessagePart,
         RoundId, Serializer,
     },
     session::signature::Keypair,
-    testing::{run_sync, BinaryFormat, TestSessionParams, TestSigner, TestVerifier},
+    testing::{run_sync, BinaryFormat, TestSessionParams, TestSigner},
 };
 use rand_core::{CryptoRngCore, OsRng};
 use tracing_subscriber::EnvFilter;
 
-use crate::simple::{Inputs, Round1, Round1Message, Round2, Round2Message};
+use crate::simple::{Round1, Round1Message, Round2, Round2Message, SimpleProtocolEntryPoint};
 
 #[derive(Debug, Clone, Copy)]
 enum Behavior {
@@ -25,7 +25,7 @@ enum Behavior {
 struct MaliciousLogic;
 
 impl<Id: PartyId> Misbehaving<Id, Behavior> for MaliciousLogic {
-    type EntryPoint = Round1<Id>;
+    type EntryPoint = SimpleProtocolEntryPoint<Id>;
 
     fn modify_direct_message(
         _rng: &mut impl CryptoRngCore,
@@ -78,9 +78,8 @@ fn serialized_garbage() {
         .iter()
         .map(|signer| signer.verifying_key())
         .collect::<BTreeSet<_>>();
-    let inputs = Inputs { all_ids };
 
-    let run_inputs = signers
+    let entry_points = signers
         .iter()
         .enumerate()
         .map(|(idx, signer)| {
@@ -90,11 +89,8 @@ fn serialized_garbage() {
                 None
             };
 
-            let malicious_inputs = MisbehavingInputs {
-                inner_inputs: inputs.clone(),
-                behavior,
-            };
-            (*signer, malicious_inputs)
+            let entry_point = MaliciousEntryPoint::new(SimpleProtocolEntryPoint::new(all_ids.clone()), behavior);
+            (*signer, entry_point)
         })
         .collect::<Vec<_>>();
 
@@ -102,7 +98,7 @@ fn serialized_garbage() {
         .with_env_filter(EnvFilter::from_default_env())
         .finish();
     let mut reports = tracing::subscriber::with_default(my_subscriber, || {
-        run_sync::<MaliciousEntryPoint<TestVerifier>, TestSessionParams<BinaryFormat>>(&mut OsRng, run_inputs).unwrap()
+        run_sync::<_, TestSessionParams<BinaryFormat>>(&mut OsRng, entry_points).unwrap()
     });
 
     let v0 = signers[0].verifying_key();
@@ -124,9 +120,8 @@ fn attributable_failure() {
         .iter()
         .map(|signer| signer.verifying_key())
         .collect::<BTreeSet<_>>();
-    let inputs = Inputs { all_ids };
 
-    let run_inputs = signers
+    let entry_points = signers
         .iter()
         .enumerate()
         .map(|(idx, signer)| {
@@ -136,11 +131,8 @@ fn attributable_failure() {
                 None
             };
 
-            let malicious_inputs = MisbehavingInputs {
-                inner_inputs: inputs.clone(),
-                behavior,
-            };
-            (*signer, malicious_inputs)
+            let entry_point = MaliciousEntryPoint::new(SimpleProtocolEntryPoint::new(all_ids.clone()), behavior);
+            (*signer, entry_point)
         })
         .collect::<Vec<_>>();
 
@@ -148,7 +140,7 @@ fn attributable_failure() {
         .with_env_filter(EnvFilter::from_default_env())
         .finish();
     let mut reports = tracing::subscriber::with_default(my_subscriber, || {
-        run_sync::<MaliciousEntryPoint<TestVerifier>, TestSessionParams<BinaryFormat>>(&mut OsRng, run_inputs).unwrap()
+        run_sync::<_, TestSessionParams<BinaryFormat>>(&mut OsRng, entry_points).unwrap()
     });
 
     let v0 = signers[0].verifying_key();
@@ -170,9 +162,8 @@ fn attributable_failure_round2() {
         .iter()
         .map(|signer| signer.verifying_key())
         .collect::<BTreeSet<_>>();
-    let inputs = Inputs { all_ids };
 
-    let run_inputs = signers
+    let entry_points = signers
         .iter()
         .enumerate()
         .map(|(idx, signer)| {
@@ -182,11 +173,8 @@ fn attributable_failure_round2() {
                 None
             };
 
-            let malicious_inputs = MisbehavingInputs {
-                inner_inputs: inputs.clone(),
-                behavior,
-            };
-            (*signer, malicious_inputs)
+            let entry_point = MaliciousEntryPoint::new(SimpleProtocolEntryPoint::new(all_ids.clone()), behavior);
+            (*signer, entry_point)
         })
         .collect::<Vec<_>>();
 
@@ -194,7 +182,7 @@ fn attributable_failure_round2() {
         .with_env_filter(EnvFilter::from_default_env())
         .finish();
     let mut reports = tracing::subscriber::with_default(my_subscriber, || {
-        run_sync::<MaliciousEntryPoint<TestVerifier>, TestSessionParams<BinaryFormat>>(&mut OsRng, run_inputs).unwrap()
+        run_sync::<_, TestSessionParams<BinaryFormat>>(&mut OsRng, entry_points).unwrap()
     });
 
     let v0 = signers[0].verifying_key();

--- a/examples/tests/async_runner.rs
+++ b/examples/tests/async_runner.rs
@@ -10,7 +10,7 @@ use manul::{
     },
     testing::{BinaryFormat, TestSessionParams, TestSigner},
 };
-use manul_example::simple::{Inputs, Round1, SimpleProtocol};
+use manul_example::simple::{SimpleProtocol, SimpleProtocolEntryPoint};
 use rand::Rng;
 use rand_core::OsRng;
 use tokio::{
@@ -256,10 +256,8 @@ async fn async_run() {
     let sessions = signers
         .into_iter()
         .map(|signer| {
-            let inputs = Inputs {
-                all_ids: all_ids.clone(),
-            };
-            SimpleSession::new::<Round1<_>>(&mut OsRng, session_id.clone(), signer, inputs).unwrap()
+            let entry_point = SimpleProtocolEntryPoint::new(all_ids.clone());
+            SimpleSession::new(&mut OsRng, session_id.clone(), signer, entry_point).unwrap()
         })
         .collect::<Vec<_>>();
 

--- a/manul/benches/empty_rounds.rs
+++ b/manul/benches/empty_rounds.rs
@@ -78,6 +78,10 @@ impl<Id: PartyId> Round<Id> for EmptyRound<Id> {
         }
     }
 
+    fn may_produce_result(&self) -> bool {
+        self.inputs.rounds_num == self.round_counter
+    }
+
     fn message_destinations(&self) -> &BTreeSet<Id> {
         &self.inputs.other_ids
     }

--- a/manul/src/combinators.rs
+++ b/manul/src/combinators.rs
@@ -1,4 +1,7 @@
 //! Combinators operating on protocols.
 
 pub mod chain;
+mod markers;
 pub mod misbehave;
+
+pub use markers::{Combinator, CombinatorEntryPoint};

--- a/manul/src/combinators/chain.rs
+++ b/manul/src/combinators/chain.rs
@@ -4,42 +4,42 @@ executes the two inner protocols in sequence, feeding the result of the first pr
 into the inputs of the second protocol.
 
 For the session level users (that is, the ones executing the protocols)
-the new protocol is a single entity with its own [`Protocol`](`crate::protocol::Protocol`) type
-and an [`EntryPoint`](`crate::protocol::EntryPoint`) type.
+the new protocol is a single entity with its own [`Protocol`](`crate::protocol::Protocol`)-implementing type
+and an [`EntryPoint`](`crate::protocol::EntryPoint`)-implementing type.
 
-For example, imagine we have a `ProtocolA` with an entry point `EntryPointA`, inputs `InputsA`,
+For example, imagine we have a `ProtocolA` with an entry point `EntryPointA`,
 two rounds, `RA1` and `RA2`, and the result `ResultA`;
-and similarly a `ProtocolB` with an entry point `EntryPointB`, inputs `InputsB`,
+and similarly a `ProtocolB` with an entry point `EntryPointB`,
 two rounds, `RB1` and `RB2`, and the result `ResultB`.
 
-Then the chained protocol will provide `ProtocolC: Protocol` and `EntryPointC: EntryPoint`,
-the user will define `InputsC` for the new protocol, and the execution will look like:
-- `InputsA` is created from `InputsC` via the user-defined `From` impl;
-- `EntryPointA` is initialized with `InputsA`;
+Then the chained protocol will have a `ProtocolC: Protocol` type and an `EntryPointC: EntryPoint` type,
+and the execution will look like:
+- `EntryPointC` is initialized by the user with whatever constructor it may have;
+- Internally, `EntryPointA` is created from `EntryPointC` using the [`ChainedSplit`] implementation
+  provided by the protocol author;
 - `RA1` is executed;
 - `RA2` is executed, producing `ResultA`;
-- `InputsB` is created from `ResultA` and `InputsC` via the user-defined `From` impl;
+- Internally, `EntryPointB` is created from `ResultA` and the data created in [`ChainedSplit::make_entry_point1`]
+  using the [`ChainedJoin`] implementation provided by the protocol author;
 - `RB1` is executed;
-- `RB2` is executed, producing `ResultB` (which is also the result of `ChainedProtocol`).
+- `RB2` is executed, producing `ResultB` (which is also the result of `ProtocolC`).
 
 If the execution happens in a [`Session`](`crate::session::Session`), and there is an error at any point,
 a regular evidence or correctness proof are created using the corresponding types from the new `ProtocolC`.
 
-The usage is as follows.
+Usage:
 
-1. Define an input type for the new joined protocol.
-   Most likely it will be a union between inputs of the first and the second protocol.
+1. Implement [`ChainedProtocol`] for a type of your choice. Usually it will be a ZST.
+   You will have to specify the two protocol types you want to chain.
+   This type will then automatically implement [`Protocol`](`crate::protocol::Protocol`).
 
-2. Implement [`Chained`] for a type of your choice. Usually it will be an empty token type.
-   You will have to specify the entry points of the two protocols,
-   and the [`From`] conversions from the new input type to the inputs of both entry points
-   (see the corresponding associated type bounds).
+2. Define an entry point type for the new joined protocol.
+   Most likely it will contain a union between the required data for the entry point
+   of the first and the second protocol.
 
-3. The entry point for the new protocol will be [`ChainedEntryPoint`] parametrized with
-   the type implementing [`Chained`] from step 2.
+3. Implement [`ChainedSplit`] and [`ChainedJoin`] for the new entry point.
 
-4. The [`Protocol`](`crate::protocol::Protocol`)-implementing type for the new protocol will be
-   [`ChainedProtocol`] parametrized with the type implementing [`Chained`] from the step 2.
+4. Mark the new entry point with the [`CombinatorEntryPoint`] trait using [`Chain`] for `Type`.
 */
 
 use alloc::{
@@ -49,70 +49,66 @@ use alloc::{
     string::String,
     vec::Vec,
 };
-use core::{fmt::Debug, marker::PhantomData};
+use core::fmt::Debug;
 
 use rand_core::CryptoRngCore;
 use serde::{Deserialize, Serialize};
 
+use super::markers::{Combinator, CombinatorEntryPoint};
 use crate::protocol::*;
 
+/// A marker for the `chain` combinator.
+#[derive(Debug, Clone, Copy)]
+pub struct Chain;
+
+impl Combinator for Chain {}
+
 /// A trait defining two protocols executed sequentially.
-pub trait Chained<Id>: 'static
-where
-    Id: PartyId,
-{
-    /// The inputs of the new chained protocol.
-    type Inputs: Send + Sync + Debug;
+pub trait ChainedProtocol: 'static + Debug {
+    /// The protcol that is executed first.
+    type Protocol1: Protocol;
 
-    /// The entry point of the first protocol.
-    type EntryPoint1: EntryPoint<Id, Inputs: for<'a> From<&'a Self::Inputs>>;
-
-    /// The entry point of the second protocol.
-    type EntryPoint2: EntryPoint<
-        Id,
-        Inputs: From<(
-            Self::Inputs,
-            <<Self::EntryPoint1 as EntryPoint<Id>>::Protocol as Protocol>::Result,
-        )>,
-    >;
+    /// The protcol that is executed second.
+    type Protocol2: Protocol;
 }
 
 /// The protocol error type for the chained protocol.
 #[derive_where::derive_where(Debug, Clone)]
 #[derive(Serialize, Deserialize)]
 #[serde(bound(serialize = "
-    <<C::EntryPoint1 as EntryPoint<Id>>::Protocol as Protocol>::ProtocolError: Serialize,
-    <<C::EntryPoint2 as EntryPoint<Id>>::Protocol as Protocol>::ProtocolError: Serialize,
+    <C::Protocol1 as Protocol>::ProtocolError: Serialize,
+    <C::Protocol2 as Protocol>::ProtocolError: Serialize,
 "))]
 #[serde(bound(deserialize = "
-    <<C::EntryPoint1 as EntryPoint<Id>>::Protocol as Protocol>::ProtocolError: for<'x> Deserialize<'x>,
-    <<C::EntryPoint2 as EntryPoint<Id>>::Protocol as Protocol>::ProtocolError: for<'x> Deserialize<'x>,
+    <C::Protocol1 as Protocol>::ProtocolError: for<'x> Deserialize<'x>,
+    <C::Protocol2 as Protocol>::ProtocolError: for<'x> Deserialize<'x>,
 "))]
-pub enum ChainedProtocolError<Id: PartyId, C: Chained<Id>> {
+pub enum ChainedProtocolError<C>
+where
+    C: ChainedProtocol,
+{
     /// A protocol error from the first protocol.
-    Protocol1(<<C::EntryPoint1 as EntryPoint<Id>>::Protocol as Protocol>::ProtocolError),
+    Protocol1(<C::Protocol1 as Protocol>::ProtocolError),
     /// A protocol error from the second protocol.
-    Protocol2(<<C::EntryPoint2 as EntryPoint<Id>>::Protocol as Protocol>::ProtocolError),
+    Protocol2(<C::Protocol2 as Protocol>::ProtocolError),
 }
 
-impl<Id, C> ChainedProtocolError<Id, C>
+impl<C> ChainedProtocolError<C>
 where
-    Id: PartyId,
-    C: Chained<Id>,
+    C: ChainedProtocol,
 {
-    fn from_protocol1(err: <<C::EntryPoint1 as EntryPoint<Id>>::Protocol as Protocol>::ProtocolError) -> Self {
+    fn from_protocol1(err: <C::Protocol1 as Protocol>::ProtocolError) -> Self {
         Self::Protocol1(err)
     }
 
-    fn from_protocol2(err: <<C::EntryPoint2 as EntryPoint<Id>>::Protocol as Protocol>::ProtocolError) -> Self {
+    fn from_protocol2(err: <C::Protocol2 as Protocol>::ProtocolError) -> Self {
         Self::Protocol2(err)
     }
 }
 
-impl<Id, C> ProtocolError for ChainedProtocolError<Id, C>
+impl<C> ProtocolError for ChainedProtocolError<C>
 where
-    Id: PartyId,
-    C: Chained<Id>,
+    C: ChainedProtocol,
 {
     fn description(&self) -> String {
         match self {
@@ -229,118 +225,138 @@ where
 #[derive_where::derive_where(Debug, Clone)]
 #[derive(Serialize, Deserialize)]
 #[serde(bound(serialize = "
-    <<C::EntryPoint1 as EntryPoint<Id>>::Protocol as Protocol>::CorrectnessProof: Serialize,
-    <<C::EntryPoint2 as EntryPoint<Id>>::Protocol as Protocol>::CorrectnessProof: Serialize,
+    <C::Protocol1 as Protocol>::CorrectnessProof: Serialize,
+    <C::Protocol2 as Protocol>::CorrectnessProof: Serialize,
 "))]
 #[serde(bound(deserialize = "
-    <<C::EntryPoint1 as EntryPoint<Id>>::Protocol as Protocol>::CorrectnessProof: for<'x> Deserialize<'x>,
-    <<C::EntryPoint2 as EntryPoint<Id>>::Protocol as Protocol>::CorrectnessProof: for<'x> Deserialize<'x>,
+    <C::Protocol1 as Protocol>::CorrectnessProof: for<'x> Deserialize<'x>,
+    <C::Protocol2 as Protocol>::CorrectnessProof: for<'x> Deserialize<'x>,
 "))]
-pub enum ChainedCorrectnessProof<Id, C>
+pub enum ChainedCorrectnessProof<C>
 where
-    Id: PartyId,
-    C: Chained<Id>,
+    C: ChainedProtocol,
 {
     /// A correctness proof from the first protocol.
-    Protocol1(<<C::EntryPoint1 as EntryPoint<Id>>::Protocol as Protocol>::CorrectnessProof),
+    Protocol1(<C::Protocol1 as Protocol>::CorrectnessProof),
     /// A correctness proof from the second protocol.
-    Protocol2(<<C::EntryPoint2 as EntryPoint<Id>>::Protocol as Protocol>::CorrectnessProof),
+    Protocol2(<C::Protocol2 as Protocol>::CorrectnessProof),
 }
 
-impl<Id, C> ChainedCorrectnessProof<Id, C>
+impl<C> ChainedCorrectnessProof<C>
 where
-    Id: PartyId,
-    C: Chained<Id>,
+    C: ChainedProtocol,
 {
-    fn from_protocol1(proof: <<C::EntryPoint1 as EntryPoint<Id>>::Protocol as Protocol>::CorrectnessProof) -> Self {
+    fn from_protocol1(proof: <C::Protocol1 as Protocol>::CorrectnessProof) -> Self {
         Self::Protocol1(proof)
     }
 
-    fn from_protocol2(proof: <<C::EntryPoint2 as EntryPoint<Id>>::Protocol as Protocol>::CorrectnessProof) -> Self {
+    fn from_protocol2(proof: <C::Protocol2 as Protocol>::CorrectnessProof) -> Self {
         Self::Protocol2(proof)
     }
 }
 
-impl<Id, C> CorrectnessProof for ChainedCorrectnessProof<Id, C>
+impl<C> CorrectnessProof for ChainedCorrectnessProof<C> where C: ChainedProtocol {}
+
+impl<C> Protocol for C
 where
-    Id: PartyId,
-    C: Chained<Id>,
+    C: ChainedProtocol,
 {
+    type Result = <C::Protocol2 as Protocol>::Result;
+    type ProtocolError = ChainedProtocolError<C>;
+    type CorrectnessProof = ChainedCorrectnessProof<C>;
 }
 
-/// The protocol resulting from chaining two sub-protocols as described by `C`.
-#[derive(Debug)]
-#[allow(clippy::type_complexity)]
-pub struct ChainedProtocol<Id: PartyId, C: Chained<Id>>(PhantomData<fn((Id, C)) -> (Id, C)>);
+/// A trait defining how the entry point for the whole chained protocol
+/// will be split into the entry point for the first protocol, and a piece of data
+/// that, along with the first protocol's result, will be used to create the entry point for the second protocol.
+pub trait ChainedSplit<Id: PartyId> {
+    /// The chained protocol this trait belongs to.
+    type Protocol: ChainedProtocol;
 
-impl<Id, C> Protocol for ChainedProtocol<Id, C>
-where
-    Id: PartyId,
-    C: Chained<Id>,
-{
-    type Result = <<C::EntryPoint2 as EntryPoint<Id>>::Protocol as Protocol>::Result;
-    type ProtocolError = ChainedProtocolError<Id, C>;
-    type CorrectnessProof = ChainedCorrectnessProof<Id, C>;
+    /// The first protocol's entry point.
+    type EntryPoint: EntryPoint<Id, Protocol = <Self::Protocol as ChainedProtocol>::Protocol1>;
+
+    /// Creates the first protocol's entry point and the data for creating the second entry point.
+    fn make_entry_point1(self) -> (Self::EntryPoint, impl ChainedJoin<Id, Protocol = Self::Protocol>);
 }
 
-/// The entry point of the chained protocol.
-#[derive_where::derive_where(Debug)]
-pub struct ChainedEntryPoint<Id: PartyId, C: Chained<Id>> {
-    state: ChainState<Id, C>,
+/// A trait defining how the data created in [`ChainedSplit::make_entry_point1`]
+/// will be joined with the result of the first protocol to create an entry point for the second protocol.
+pub trait ChainedJoin<Id: PartyId>: 'static + Debug + Send + Sync {
+    /// The chained protocol this trait belongs to.
+    type Protocol: ChainedProtocol;
+
+    /// The second protocol's entry point.
+    type EntryPoint: EntryPoint<Id, Protocol = <Self::Protocol as ChainedProtocol>::Protocol2>;
+
+    /// Creates the second protocol's entry point using the first protocol's result.
+    fn make_entry_point2(
+        self,
+        result: <<Self::Protocol as ChainedProtocol>::Protocol1 as Protocol>::Result,
+    ) -> Self::EntryPoint;
 }
 
-#[derive_where::derive_where(Debug)]
-enum ChainState<Id, C>
+impl<Id, T> EntryPoint<Id> for T
 where
     Id: PartyId,
-    C: Chained<Id>,
+    T: ChainedSplit<Id> + CombinatorEntryPoint<Combinator = Chain>,
 {
-    Protocol1 {
-        round: BoxedRound<Id, <C::EntryPoint1 as EntryPoint<Id>>::Protocol>,
-        shared_randomness: Box<[u8]>,
-        id: Id,
-        inputs: C::Inputs,
-    },
-    Protocol2(BoxedRound<Id, <C::EntryPoint2 as EntryPoint<Id>>::Protocol>),
-}
-
-impl<Id, C> EntryPoint<Id> for ChainedEntryPoint<Id, C>
-where
-    Id: PartyId,
-    C: Chained<Id>,
-{
-    type Inputs = C::Inputs;
-    type Protocol = ChainedProtocol<Id, C>;
+    type Protocol = T::Protocol;
 
     fn entry_round() -> RoundId {
-        <C::EntryPoint1 as EntryPoint<Id>>::entry_round().group_under(1)
+        <T as ChainedSplit<Id>>::EntryPoint::entry_round().group_under(1)
     }
 
-    fn new(
+    fn make_round(
+        self,
         rng: &mut impl CryptoRngCore,
         shared_randomness: &[u8],
-        id: Id,
-        inputs: Self::Inputs,
+        id: &Id,
     ) -> Result<BoxedRound<Id, Self::Protocol>, LocalError> {
-        let round = C::EntryPoint1::new(rng, shared_randomness, id.clone(), (&inputs).into())?;
-        let round = ChainedEntryPoint {
+        let (entry_point, transition) = self.make_entry_point1();
+        let round = entry_point.make_round(rng, shared_randomness, id)?;
+        let chained_round = ChainedRound {
             state: ChainState::Protocol1 {
+                id: id.clone(),
                 shared_randomness: shared_randomness.into(),
-                id,
-                inputs,
+                transition,
                 round,
             },
         };
-        Ok(BoxedRound::new_object_safe(round))
+        Ok(BoxedRound::new_object_safe(chained_round))
     }
 }
 
-impl<Id, C> ObjectSafeRound<Id> for ChainedEntryPoint<Id, C>
+#[derive(Debug)]
+struct ChainedRound<Id, T>
 where
     Id: PartyId,
-    C: Chained<Id>,
+    T: ChainedJoin<Id>,
 {
-    type Protocol = ChainedProtocol<Id, C>;
+    state: ChainState<Id, T>,
+}
+
+#[derive_where::derive_where(Debug)]
+enum ChainState<Id, T>
+where
+    Id: PartyId,
+    T: ChainedJoin<Id>,
+{
+    Protocol1 {
+        id: Id,
+        round: BoxedRound<Id, <T::Protocol as ChainedProtocol>::Protocol1>,
+        shared_randomness: Box<[u8]>,
+        transition: T,
+    },
+    Protocol2(BoxedRound<Id, <T::Protocol as ChainedProtocol>::Protocol2>),
+}
+
+impl<Id, T> ObjectSafeRound<Id> for ChainedRound<Id, T>
+where
+    Id: PartyId,
+    T: ChainedJoin<Id>,
+{
+    type Protocol = T::Protocol;
 
     fn id(&self) -> RoundId {
         match &self.state {
@@ -362,7 +378,7 @@ where
                 // If there are no next rounds, this is the result round.
                 // This means that in the chain the next round will be the entry round of the second protocol.
                 if next_rounds.is_empty() {
-                    next_rounds.insert(C::EntryPoint2::entry_round().group_under(2));
+                    next_rounds.insert(T::EntryPoint::entry_round().group_under(2));
                 }
                 next_rounds
             }
@@ -484,28 +500,29 @@ where
     ) -> Result<FinalizeOutcome<Id, Self::Protocol>, FinalizeError<Self::Protocol>> {
         match self.state {
             ChainState::Protocol1 {
-                round,
                 id,
-                inputs,
+                round,
+                transition,
                 shared_randomness,
             } => match round.into_boxed().finalize(rng, payloads, artifacts) {
                 Ok(FinalizeOutcome::Result(result)) => {
                     let mut boxed_rng = BoxedRng(rng);
-                    let round = C::EntryPoint2::new(&mut boxed_rng, &shared_randomness, id, (inputs, result).into())?;
+                    let entry_point2 = transition.make_entry_point2(result);
+                    let round = entry_point2.make_round(&mut boxed_rng, &shared_randomness, &id)?;
 
                     Ok(FinalizeOutcome::AnotherRound(BoxedRound::new_object_safe(
-                        ChainedEntryPoint::<Id, C> {
+                        ChainedRound::<Id, T> {
                             state: ChainState::Protocol2(round),
                         },
                     )))
                 }
                 Ok(FinalizeOutcome::AnotherRound(round)) => Ok(FinalizeOutcome::AnotherRound(
-                    BoxedRound::new_object_safe(ChainedEntryPoint::<Id, C> {
+                    BoxedRound::new_object_safe(ChainedRound::<Id, T> {
                         state: ChainState::Protocol1 {
-                            shared_randomness,
                             id,
-                            inputs,
+                            shared_randomness,
                             round,
+                            transition,
                         },
                     }),
                 )),
@@ -517,7 +534,7 @@ where
             ChainState::Protocol2(round) => match round.into_boxed().finalize(rng, payloads, artifacts) {
                 Ok(FinalizeOutcome::Result(result)) => Ok(FinalizeOutcome::Result(result)),
                 Ok(FinalizeOutcome::AnotherRound(round)) => Ok(FinalizeOutcome::AnotherRound(
-                    BoxedRound::new_object_safe(ChainedEntryPoint::<Id, C> {
+                    BoxedRound::new_object_safe(ChainedRound::<Id, T> {
                         state: ChainState::Protocol2(round),
                     }),
                 )),

--- a/manul/src/combinators/chain.rs
+++ b/manul/src/combinators/chain.rs
@@ -375,11 +375,11 @@ where
                     .map(|round_id| round_id.group_under(1))
                     .collect::<BTreeSet<_>>();
 
-                // If there are no next rounds, this is the result round.
-                // This means that in the chain the next round will be the entry round of the second protocol.
-                if next_rounds.is_empty() {
+                if round.as_ref().may_produce_result() {
+                    tracing::debug!("Adding {}", T::EntryPoint::entry_round().group_under(2));
                     next_rounds.insert(T::EntryPoint::entry_round().group_under(2));
                 }
+
                 next_rounds
             }
             ChainState::Protocol2(round) => round
@@ -388,6 +388,13 @@ where
                 .into_iter()
                 .map(|round_id| round_id.group_under(2))
                 .collect(),
+        }
+    }
+
+    fn may_produce_result(&self) -> bool {
+        match &self.state {
+            ChainState::Protocol1 { .. } => false,
+            ChainState::Protocol2(round) => round.as_ref().may_produce_result(),
         }
     }
 

--- a/manul/src/combinators/markers.rs
+++ b/manul/src/combinators/markers.rs
@@ -1,0 +1,9 @@
+/// A marker trait for protocol combinators.
+pub trait Combinator {}
+
+/// Marks an entry point for a protocol combinator result, so that [`EntryPoint`](`crate::protocol::EntryPoint`)
+/// can be derived automatically for it.
+pub trait CombinatorEntryPoint {
+    /// The type of the combinator.
+    type Combinator: Combinator;
+}

--- a/manul/src/combinators/misbehave.rs
+++ b/manul/src/combinators/misbehave.rs
@@ -179,6 +179,10 @@ where
         self.round.as_ref().possible_next_rounds()
     }
 
+    fn may_produce_result(&self) -> bool {
+        self.round.as_ref().may_produce_result()
+    }
+
     fn message_destinations(&self) -> &BTreeSet<Id> {
         self.round.as_ref().message_destinations()
     }

--- a/manul/src/combinators/misbehave.rs
+++ b/manul/src/combinators/misbehave.rs
@@ -1,12 +1,12 @@
 /*!
 A combinator allowing one to intercept outgoing messages from a round, and replace or modify them.
 
-The usage is as follows:
+Usage:
 
 1. Define a behavior type, subject to [`Behavior`] bounds.
    This will represent the possible actions the override may perform.
 
-2. Implement [`Misbehaving`] for a type of your choice. Usually it will be an empty token type.
+2. Implement [`Misbehaving`] for a type of your choice. Usually it will be a ZST.
    You will need to specify the entry point for the unmodified protocol,
    and some of `modify_*` methods (the blanket implementations simply pass through the original messages).
 
@@ -18,6 +18,9 @@ The usage is as follows:
 
 5. You can get access to the typed `Round` object by using
    [`BoxedRound::downcast_ref`](`crate::protocol::BoxedRound::downcast_ref`).
+
+6. Use [`MisbehavingEntryPoint`] parametrized by `Id`, the behavior type from step 1, and the type from step 2
+   as the entry point of the new protocol.
 */
 
 use alloc::{
@@ -39,20 +42,6 @@ pub trait Behavior: 'static + Debug + Send + Sync {}
 
 impl<T: 'static + Debug + Send + Sync> Behavior for T {}
 
-/// The new entry point for the misbehaving rounds.
-///
-/// Use as an entry point to run the session, with your ID, behavior `B` and the misbehavior definition `M` set.
-#[derive_where::derive_where(Debug)]
-pub struct MisbehavingEntryPoint<Id, B, M>
-where
-    Id: PartyId,
-    B: Behavior,
-    M: Misbehaving<Id, B>,
-{
-    round: BoxedRound<Id, <M::EntryPoint as EntryPoint<Id>>::Protocol>,
-    behavior: Option<B>,
-}
-
 /// A trait defining a sequence of misbehaving rounds modifying or replacing the messages sent by some existing ones.
 ///
 /// Override one or more optional methods to modify the specific messages.
@@ -62,7 +51,7 @@ where
     B: Behavior,
 {
     /// The entry point of the wrapped rounds.
-    type EntryPoint: EntryPoint<Id>;
+    type EntryPoint: Debug + EntryPoint<Id>;
 
     /// Called after [`Round::make_echo_broadcast`](`crate::protocol::Round::make_echo_broadcast`)
     /// and may modify its result.
@@ -115,20 +104,30 @@ where
     }
 }
 
-/// The inputs for the misbehaving rounds.
-#[derive_where::derive_where(Debug; <M::EntryPoint as EntryPoint<Id>>::Inputs)]
-pub struct MisbehavingInputs<Id, B, M>
+/// The new entry point for the misbehaving rounds.
+///
+/// Use as an entry point to run the session, with your ID, the behavior `B` and the misbehavior definition `M` set.
+#[derive_where::derive_where(Debug)]
+pub struct MisbehavingEntryPoint<Id, B, M>
 where
     Id: PartyId,
     B: Behavior,
     M: Misbehaving<Id, B>,
 {
-    /// The behavior for the rounds starting with these inputs.
-    ///
-    /// If `None`, all the changed behavior will be skipped.
-    pub behavior: Option<B>,
-    /// The inputs for the wrapped rounds.
-    pub inner_inputs: <M::EntryPoint as EntryPoint<Id>>::Inputs,
+    entry_point: M::EntryPoint,
+    behavior: Option<B>,
+}
+
+impl<Id, B, M> MisbehavingEntryPoint<Id, B, M>
+where
+    Id: PartyId,
+    B: Behavior,
+    M: Misbehaving<Id, B>,
+{
+    /// Creates an entry point for the misbehaving protocol using an entry point for the inner protocol.
+    pub fn new(entry_point: M::EntryPoint, behavior: Option<B>) -> Self {
+        Self { entry_point, behavior }
+    }
 }
 
 impl<Id, B, M> EntryPoint<Id> for MisbehavingEntryPoint<Id, B, M>
@@ -137,24 +136,34 @@ where
     B: Behavior,
     M: Misbehaving<Id, B>,
 {
-    type Inputs = MisbehavingInputs<Id, B, M>;
     type Protocol = <M::EntryPoint as EntryPoint<Id>>::Protocol;
 
-    fn new(
+    fn make_round(
+        self,
         rng: &mut impl CryptoRngCore,
         shared_randomness: &[u8],
-        id: Id,
-        inputs: Self::Inputs,
-    ) -> Result<BoxedRound<Id, <M::EntryPoint as EntryPoint<Id>>::Protocol>, LocalError> {
-        let round = M::EntryPoint::new(rng, shared_randomness, id, inputs.inner_inputs)?;
-        Ok(BoxedRound::new_object_safe(Self {
+        id: &Id,
+    ) -> Result<BoxedRound<Id, Self::Protocol>, LocalError> {
+        let round = self.entry_point.make_round(rng, shared_randomness, id)?;
+        Ok(BoxedRound::new_object_safe(MisbehavingRound::<Id, B, M> {
             round,
-            behavior: inputs.behavior,
+            behavior: self.behavior,
         }))
     }
 }
 
-impl<Id, B, M> ObjectSafeRound<Id> for MisbehavingEntryPoint<Id, B, M>
+#[derive_where::derive_where(Debug)]
+struct MisbehavingRound<Id, B, M>
+where
+    Id: PartyId,
+    B: Behavior,
+    M: Misbehaving<Id, B>,
+{
+    round: BoxedRound<Id, <M::EntryPoint as EntryPoint<Id>>::Protocol>,
+    behavior: Option<B>,
+}
+
+impl<Id, B, M> ObjectSafeRound<Id> for MisbehavingRound<Id, B, M>
 where
     Id: PartyId,
     B: Behavior,
@@ -284,12 +293,12 @@ where
     ) -> Result<FinalizeOutcome<Id, Self::Protocol>, FinalizeError<Self::Protocol>> {
         match self.round.into_boxed().finalize(rng, payloads, artifacts) {
             Ok(FinalizeOutcome::Result(result)) => Ok(FinalizeOutcome::Result(result)),
-            Ok(FinalizeOutcome::AnotherRound(round)) => Ok(FinalizeOutcome::AnotherRound(BoxedRound::new_object_safe(
-                MisbehavingEntryPoint::<Id, B, M> {
+            Ok(FinalizeOutcome::AnotherRound(round)) => {
+                Ok(FinalizeOutcome::AnotherRound(BoxedRound::new_object_safe(Self {
                     round,
                     behavior: self.behavior,
-                },
-            ))),
+                })))
+            }
             Err(err) => Err(err),
         }
     }

--- a/manul/src/protocol/object_safe.rs
+++ b/manul/src/protocol/object_safe.rs
@@ -209,7 +209,7 @@ where
 
 // We do not want to expose `ObjectSafeRound` to the user, so it is hidden in a struct.
 /// A wrapped new round that may be returned by [`Round::finalize`]
-/// or [`EntryPoint::new`](`crate::protocol::EntryPoint::new`).
+/// or [`EntryPoint::make_round`](`crate::protocol::EntryPoint::make_round`).
 #[derive_where::derive_where(Debug)]
 pub struct BoxedRound<Id: PartyId, P: Protocol> {
     wrapped: bool,

--- a/manul/src/protocol/object_safe.rs
+++ b/manul/src/protocol/object_safe.rs
@@ -46,6 +46,8 @@ pub(crate) trait ObjectSafeRound<Id: PartyId>: 'static + Debug + Send + Sync {
 
     fn possible_next_rounds(&self) -> BTreeSet<RoundId>;
 
+    fn may_produce_result(&self) -> bool;
+
     fn message_destinations(&self) -> &BTreeSet<Id>;
 
     fn expecting_messages_from(&self) -> &BTreeSet<Id>;
@@ -131,6 +133,10 @@ where
 
     fn possible_next_rounds(&self) -> BTreeSet<RoundId> {
         self.round.possible_next_rounds()
+    }
+
+    fn may_produce_result(&self) -> bool {
+        self.round.may_produce_result()
     }
 
     fn message_destinations(&self) -> &BTreeSet<Id> {

--- a/manul/src/protocol/round.rs
+++ b/manul/src/protocol/round.rs
@@ -341,13 +341,10 @@ impl Artifact {
 /// This is a round that can be created directly;
 /// all the others are only reachable throud [`Round::finalize`] by the execution layer.
 pub trait EntryPoint<Id: PartyId> {
-    /// Additional inputs for the protocol (besides the mandatory ones in [`new`](`Self::new`)).
-    type Inputs;
-
     /// The protocol implemented by the round this entry points returns.
     type Protocol: Protocol;
 
-    /// Returns the ID of the round returned by [`Self::new`].
+    /// Returns the ID of the round returned by [`Self::make_round`].
     fn entry_round() -> RoundId {
         RoundId::new(1)
     }
@@ -356,11 +353,11 @@ pub trait EntryPoint<Id: PartyId> {
     ///
     /// `session_id` can be assumed to be the same for each node participating in a session.
     /// `id` is the ID of this node.
-    fn new(
+    fn make_round(
+        self,
         rng: &mut impl CryptoRngCore,
         shared_randomness: &[u8],
-        id: Id,
-        inputs: Self::Inputs,
+        id: &Id,
     ) -> Result<BoxedRound<Id, Self::Protocol>, LocalError>;
 }
 

--- a/manul/src/protocol/round.rs
+++ b/manul/src/protocol/round.rs
@@ -408,6 +408,13 @@ pub trait Round<Id: PartyId>: 'static + Debug + Send + Sync {
     /// Returns an empty set if this round only finalizes into a result.
     fn possible_next_rounds(&self) -> BTreeSet<RoundId>;
 
+    /// Returns ``true`` if this round's [`Round::finalize`] may return [`FinalizeOutcome::Result`].
+    ///
+    /// The blanket implementation returns ``false``.
+    fn may_produce_result(&self) -> bool {
+        false
+    }
+
     /// The destinations of the messages to be sent out by this round.
     ///
     /// The way it is interpreted by the execution layer is

--- a/manul/src/session/session.rs
+++ b/manul/src/session/session.rs
@@ -142,17 +142,16 @@ where
     SP: SessionParameters,
 {
     /// Initializes a new session.
-    pub fn new<R>(
+    pub fn new<EP>(
         rng: &mut impl CryptoRngCore,
         session_id: SessionId,
         signer: SP::Signer,
-        inputs: R::Inputs,
+        entry_point: EP,
     ) -> Result<Self, LocalError>
     where
-        R: EntryPoint<SP::Verifier, Protocol = P>,
+        EP: EntryPoint<SP::Verifier, Protocol = P>,
     {
-        let verifier = signer.verifying_key();
-        let first_round = R::new(rng, session_id.as_ref(), verifier.clone(), inputs)?;
+        let first_round = entry_point.make_round(rng, session_id.as_ref(), &signer.verifying_key())?;
         let serializer = Serializer::new::<SP::WireFormat>();
         let deserializer = Deserializer::new::<SP::WireFormat>();
         Self::new_for_next_round(


### PR DESCRIPTION
Stacked on top of #67

This PR makes `EntryPoint`  types stateful - that is, this removes the need for `EntryPoint::Inputs` because the `EntryPoint`-implementing type becomes the inputs itself. Fixes #64.

Benefits:
- No need to expose `Round` types, only the `EntryPoint` impl can be public
- Protocol writers can write custom constructors (basically what we do in `synedrion` in `constructors.rs`) with additional consistency checks or convenience methods

Also added `Round::may_produce_result()`. Fixes #66