### PR TITLE
Remove `CorrectnessProof`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Entry points are now stateful; combinator API reworked accordingly. ([#68])
 - `run_sync()` now returns an `ExecutionResult` object. ([#71])
 - `testing` module and feature renamed to `dev` to avoid confusion with tests. ([#71])
+- Correctness proofs are removed from the API. Consequently, `FinalizeError` is removed, and `Round::finalize()` returns a `Result<..., LocalError>`) ([#72])
 
 
 ### Added
@@ -63,6 +64,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#67]: https://github.com/entropyxyz/manul/pull/67
 [#68]: https://github.com/entropyxyz/manul/pull/68
 [#71]: https://github.com/entropyxyz/manul/pull/71
+[#72]: https://github.com/entropyxyz/manul/pull/72
 
 
 ## [0.0.1] - 2024-10-12

--- a/examples/src/simple_chain.rs
+++ b/examples/src/simple_chain.rs
@@ -95,7 +95,7 @@ mod tests {
             .unwrap();
 
         for (_id, result) in results {
-            assert_eq!(result, 3); // 0 + 1 + 2
+            assert_eq!(result, 6); // (0 + 1 + 2) * 2
         }
     }
 }

--- a/manul/benches/empty_rounds.rs
+++ b/manul/benches/empty_rounds.rs
@@ -7,9 +7,8 @@ use criterion::{criterion_group, criterion_main, Criterion};
 use manul::{
     dev::{run_sync, BinaryFormat, TestSessionParams, TestSigner},
     protocol::{
-        Artifact, BoxedRound, Deserializer, DirectMessage, EchoBroadcast, EntryPoint, FinalizeError, FinalizeOutcome,
-        LocalError, NormalBroadcast, PartyId, Payload, Protocol, ProtocolMessagePart, ReceiveError, Round, RoundId,
-        Serializer,
+        Artifact, BoxedRound, Deserializer, DirectMessage, EchoBroadcast, EntryPoint, FinalizeOutcome, LocalError,
+        NormalBroadcast, PartyId, Payload, Protocol, ProtocolMessagePart, ReceiveError, Round, RoundId, Serializer,
     },
     session::signature::Keypair,
 };
@@ -22,7 +21,6 @@ pub struct EmptyProtocol;
 impl Protocol for EmptyProtocol {
     type Result = ();
     type ProtocolError = ();
-    type CorrectnessProof = ();
 }
 
 #[derive(Debug)]
@@ -133,7 +131,7 @@ impl<Id: PartyId> Round<Id> for EmptyRound<Id> {
         _rng: &mut impl CryptoRngCore,
         payloads: BTreeMap<Id, Payload>,
         artifacts: BTreeMap<Id, Artifact>,
-    ) -> Result<FinalizeOutcome<Id, Self::Protocol>, FinalizeError<Self::Protocol>> {
+    ) -> Result<FinalizeOutcome<Id, Self::Protocol>, LocalError> {
         for payload in payloads.into_values() {
             let _payload = payload.try_to_typed::<Round1Payload>()?;
         }

--- a/manul/src/combinators/misbehave.rs
+++ b/manul/src/combinators/misbehave.rs
@@ -33,8 +33,7 @@ use rand_core::CryptoRngCore;
 
 use crate::protocol::{
     Artifact, BoxedRng, BoxedRound, Deserializer, DirectMessage, EchoBroadcast, EchoRoundParticipation, EntryPoint,
-    FinalizeError, FinalizeOutcome, LocalError, NormalBroadcast, ObjectSafeRound, PartyId, Payload, ReceiveError,
-    RoundId, Serializer,
+    FinalizeOutcome, LocalError, NormalBroadcast, ObjectSafeRound, PartyId, Payload, ReceiveError, RoundId, Serializer,
 };
 
 /// A trait describing required properties for a behavior type.
@@ -294,16 +293,15 @@ where
         rng: &mut dyn CryptoRngCore,
         payloads: BTreeMap<Id, Payload>,
         artifacts: BTreeMap<Id, Artifact>,
-    ) -> Result<FinalizeOutcome<Id, Self::Protocol>, FinalizeError<Self::Protocol>> {
-        match self.round.into_boxed().finalize(rng, payloads, artifacts) {
-            Ok(FinalizeOutcome::Result(result)) => Ok(FinalizeOutcome::Result(result)),
-            Ok(FinalizeOutcome::AnotherRound(round)) => {
+    ) -> Result<FinalizeOutcome<Id, Self::Protocol>, LocalError> {
+        match self.round.into_boxed().finalize(rng, payloads, artifacts)? {
+            FinalizeOutcome::Result(result) => Ok(FinalizeOutcome::Result(result)),
+            FinalizeOutcome::AnotherRound(round) => {
                 Ok(FinalizeOutcome::AnotherRound(BoxedRound::new_object_safe(Self {
                     round,
                     behavior: self.behavior,
                 })))
             }
-            Err(err) => Err(err),
         }
     }
 }

--- a/manul/src/protocol.rs
+++ b/manul/src/protocol.rs
@@ -18,14 +18,14 @@ mod round;
 mod serialization;
 
 pub use errors::{
-    DeserializationError, DirectMessageError, EchoBroadcastError, FinalizeError, LocalError, MessageValidationError,
+    DeserializationError, DirectMessageError, EchoBroadcastError, LocalError, MessageValidationError,
     NormalBroadcastError, ProtocolValidationError, ReceiveError, RemoteError,
 };
 pub use message::{DirectMessage, EchoBroadcast, NormalBroadcast, ProtocolMessagePart};
 pub use object_safe::BoxedRound;
 pub use round::{
-    Artifact, CorrectnessProof, EchoRoundParticipation, EntryPoint, FinalizeOutcome, PartyId, Payload, Protocol,
-    ProtocolError, Round, RoundId,
+    Artifact, EchoRoundParticipation, EntryPoint, FinalizeOutcome, PartyId, Payload, Protocol, ProtocolError, Round,
+    RoundId,
 };
 pub use serialization::{Deserializer, Serializer};
 

--- a/manul/src/protocol/errors.rs
+++ b/manul/src/protocol/errors.rs
@@ -151,21 +151,6 @@ where
     }
 }
 
-/// An error that can occur during [`Round::finalize`](`super::Round::finalize`).
-#[derive(Debug)]
-pub enum FinalizeError<P: Protocol> {
-    /// A local error, usually indicating a bug in the implementation.
-    Local(LocalError),
-    /// An unattributable error, with an attached proof that this node performed its duties correctly.
-    Unattributable(P::CorrectnessProof),
-}
-
-impl<P: Protocol> From<LocalError> for FinalizeError<P> {
-    fn from(error: LocalError) -> Self {
-        Self::Local(error)
-    }
-}
-
 /// An error that can occur during the validation of an evidence of an invalid message.
 #[derive(Debug, Clone)]
 pub enum MessageValidationError {

--- a/manul/src/protocol/object_safe.rs
+++ b/manul/src/protocol/object_safe.rs
@@ -8,7 +8,7 @@ use core::{fmt::Debug, marker::PhantomData};
 use rand_core::{CryptoRng, CryptoRngCore, RngCore};
 
 use super::{
-    errors::{FinalizeError, LocalError, ReceiveError},
+    errors::{LocalError, ReceiveError},
     message::{DirectMessage, EchoBroadcast, NormalBroadcast},
     round::{Artifact, EchoRoundParticipation, FinalizeOutcome, PartyId, Payload, Protocol, Round, RoundId},
     serialization::{Deserializer, Serializer},
@@ -91,7 +91,7 @@ pub(crate) trait ObjectSafeRound<Id: PartyId>: 'static + Debug + Send + Sync {
         rng: &mut dyn CryptoRngCore,
         payloads: BTreeMap<Id, Payload>,
         artifacts: BTreeMap<Id, Artifact>,
-    ) -> Result<FinalizeOutcome<Id, Self::Protocol>, FinalizeError<Self::Protocol>>;
+    ) -> Result<FinalizeOutcome<Id, Self::Protocol>, LocalError>;
 
     /// Returns the type ID of the implementing type.
     fn get_type_id(&self) -> core::any::TypeId {
@@ -207,7 +207,7 @@ where
         rng: &mut dyn CryptoRngCore,
         payloads: BTreeMap<Id, Payload>,
         artifacts: BTreeMap<Id, Artifact>,
-    ) -> Result<FinalizeOutcome<Id, Self::Protocol>, FinalizeError<Self::Protocol>> {
+    ) -> Result<FinalizeOutcome<Id, Self::Protocol>, LocalError> {
         let mut boxed_rng = BoxedRng(rng);
         self.round.finalize(&mut boxed_rng, payloads, artifacts)
     }

--- a/manul/src/session/echo.rs
+++ b/manul/src/session/echo.rs
@@ -17,9 +17,8 @@ use super::{
 };
 use crate::{
     protocol::{
-        Artifact, BoxedRound, Deserializer, DirectMessage, EchoBroadcast, FinalizeError, FinalizeOutcome,
-        MessageValidationError, NormalBroadcast, Payload, Protocol, ProtocolMessagePart, ReceiveError, Round, RoundId,
-        Serializer,
+        Artifact, BoxedRound, Deserializer, DirectMessage, EchoBroadcast, FinalizeOutcome, MessageValidationError,
+        NormalBroadcast, Payload, Protocol, ProtocolMessagePart, ReceiveError, Round, RoundId, Serializer,
     },
     utils::SerializableMap,
 };
@@ -286,7 +285,7 @@ where
         rng: &mut impl CryptoRngCore,
         _payloads: BTreeMap<SP::Verifier, Payload>,
         _artifacts: BTreeMap<SP::Verifier, Artifact>,
-    ) -> Result<FinalizeOutcome<SP::Verifier, Self::Protocol>, FinalizeError<Self::Protocol>> {
+    ) -> Result<FinalizeOutcome<SP::Verifier, Self::Protocol>, LocalError> {
         self.main_round
             .into_boxed()
             .finalize(rng, self.payloads, self.artifacts)

--- a/manul/src/session/transcript.rs
+++ b/manul/src/session/transcript.rs
@@ -173,12 +173,6 @@ where
 pub enum SessionOutcome<P: Protocol> {
     /// The protocol successfully produced a result.
     Result(P::Result),
-    /// The execution stalled because of an unattributable error,
-    /// but the protocol created a proof that this node performed its duties correctly.
-    ///
-    /// This proof is supposed to be passed to a third party for adjudication,
-    /// along with the proofs from the other nodes.
-    StalledWithProof(P::CorrectnessProof),
     /// The execution stalled because not enough messages were received to finalize the round.
     NotEnoughMessages,
     /// The execution was terminated by the user.
@@ -195,7 +189,6 @@ where
             Self::Result(result) => format!("Success ({result:?})"),
             Self::NotEnoughMessages => "Not enough messages to finalize, terminated".into(),
             Self::Terminated => "Terminated by the user".into(),
-            Self::StalledWithProof(_) => "Unattributable failure during finalization".into(),
         }
     }
 }

--- a/manul/src/tests/partial_echo.rs
+++ b/manul/src/tests/partial_echo.rs
@@ -22,7 +22,6 @@ struct PartialEchoProtocol;
 impl Protocol for PartialEchoProtocol {
     type Result = ();
     type ProtocolError = PartialEchoProtocolError;
-    type CorrectnessProof = ();
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -146,7 +145,7 @@ impl<Id: PartyId + Serialize + for<'de> Deserialize<'de>> Round<Id> for Round1<I
         _rng: &mut impl CryptoRngCore,
         _payloads: BTreeMap<Id, Payload>,
         _artifacts: BTreeMap<Id, Artifact>,
-    ) -> Result<FinalizeOutcome<Id, Self::Protocol>, FinalizeError<Self::Protocol>> {
+    ) -> Result<FinalizeOutcome<Id, Self::Protocol>, LocalError> {
         Ok(FinalizeOutcome::Result(()))
     }
 }


### PR DESCRIPTION
Stacked on top of #71

Closes #2

- Remove `CorrectnessProof`.
- Since `FinalizeError` only contains `LocalError` now, it is removed as well and replaced with just `LocalError`.

I think it is safe to assume that any attributable error in the protocol would occur at `receive_message()` stage. At least for now, I would like to see an example of a protocol where it is not the case.