### PR TITLE
Adjust re-exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,17 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
+## [0.2.0] - in development
+
+### Changed
+
+- Removed `protocol::digest` re-export ([#75]).
+
+
+[#75]: https://github.com/entropyxyz/manul/pull/75
+
+
 ## [0.1.0] - 2024-11-19
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Removed `protocol::digest` re-export ([#75]).
+- `digest` and `signature` are now re-exported from the top level instead of `session` ([#75]).
 
 
 [#75]: https://github.com/entropyxyz/manul/pull/75

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -551,7 +551,7 @@ checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 
 [[package]]
 name = "manul"
-version = "0.1.0"
+version = "0.2.0-dev"
 dependencies = [
  "criterion",
  "derive-where",

--- a/examples/src/simple.rs
+++ b/examples/src/simple.rs
@@ -405,7 +405,7 @@ mod tests {
 
     use manul::{
         dev::{run_sync, BinaryFormat, TestSessionParams, TestSigner},
-        session::signature::Keypair,
+        signature::Keypair,
     };
     use rand_core::OsRng;
     use test_log::test;

--- a/examples/src/simple.rs
+++ b/examples/src/simple.rs
@@ -5,7 +5,11 @@ use alloc::{
 };
 use core::fmt::Debug;
 
-use manul::protocol::*;
+use manul::protocol::{
+    Artifact, BoxedRound, Deserializer, DirectMessage, EchoBroadcast, EntryPoint, FinalizeOutcome, LocalError,
+    MessageValidationError, NormalBroadcast, PartyId, Payload, Protocol, ProtocolError, ProtocolMessagePart,
+    ProtocolValidationError, ReceiveError, Round, RoundId, Serializer,
+};
 use rand_core::CryptoRngCore;
 use serde::{Deserialize, Serialize};
 use tracing::debug;

--- a/examples/src/simple_chain.rs
+++ b/examples/src/simple_chain.rs
@@ -71,7 +71,7 @@ mod tests {
 
     use manul::{
         dev::{run_sync, BinaryFormat, TestSessionParams, TestSigner},
-        session::signature::Keypair,
+        signature::Keypair,
     };
     use rand_core::OsRng;
     use test_log::test;

--- a/examples/src/simple_malicious.rs
+++ b/examples/src/simple_malicious.rs
@@ -8,7 +8,7 @@ use manul::{
         Artifact, BoxedRound, Deserializer, DirectMessage, EntryPoint, LocalError, PartyId, ProtocolMessagePart,
         RoundId, Serializer,
     },
-    session::signature::Keypair,
+    signature::Keypair,
 };
 use rand_core::{CryptoRngCore, OsRng};
 use test_log::test;

--- a/examples/tests/async_runner.rs
+++ b/examples/tests/async_runner.rs
@@ -5,10 +5,8 @@ use alloc::collections::{BTreeMap, BTreeSet};
 use manul::{
     dev::{BinaryFormat, TestSessionParams, TestSigner},
     protocol::Protocol,
-    session::{
-        signature::Keypair, CanFinalize, LocalError, Message, RoundOutcome, Session, SessionId, SessionParameters,
-        SessionReport,
-    },
+    session::{CanFinalize, LocalError, Message, RoundOutcome, Session, SessionId, SessionParameters, SessionReport},
+    signature::Keypair,
 };
 use manul_example::simple::{SimpleProtocol, SimpleProtocolEntryPoint};
 use rand::Rng;

--- a/manul/Cargo.toml
+++ b/manul/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "manul"
-version = "0.1.0"
+version = "0.2.0-dev"
 edition = "2021"
 rust-version = "1.81"
 authors = ['Entropy Cryptography <engineering@entropy.xyz>']

--- a/manul/benches/empty_rounds.rs
+++ b/manul/benches/empty_rounds.rs
@@ -10,7 +10,7 @@ use manul::{
         Artifact, BoxedRound, Deserializer, DirectMessage, EchoBroadcast, EntryPoint, FinalizeOutcome, LocalError,
         NormalBroadcast, PartyId, Payload, Protocol, ProtocolMessagePart, ReceiveError, Round, RoundId, Serializer,
     },
-    session::signature::Keypair,
+    signature::Keypair,
 };
 use rand_core::{CryptoRngCore, OsRng};
 use serde::{Deserialize, Serialize};

--- a/manul/src/combinators/chain.rs
+++ b/manul/src/combinators/chain.rs
@@ -55,7 +55,11 @@ use rand_core::CryptoRngCore;
 use serde::{Deserialize, Serialize};
 
 use super::markers::{Combinator, CombinatorEntryPoint};
-use crate::protocol::*;
+use crate::protocol::{
+    Artifact, BoxedRng, BoxedRound, Deserializer, DirectMessage, EchoBroadcast, EchoRoundParticipation, EntryPoint,
+    FinalizeOutcome, LocalError, NormalBroadcast, ObjectSafeRound, PartyId, Payload, Protocol, ProtocolError,
+    ProtocolValidationError, ReceiveError, RoundId, Serializer,
+};
 
 /// A marker for the `chain` combinator.
 #[derive(Debug, Clone, Copy)]

--- a/manul/src/lib.rs
+++ b/manul/src/lib.rs
@@ -25,3 +25,7 @@ pub mod dev;
 
 #[cfg(test)]
 mod tests;
+
+// Re-exports for easier version matching
+pub use digest;
+pub use signature;

--- a/manul/src/protocol.rs
+++ b/manul/src/protocol.rs
@@ -31,5 +31,3 @@ pub use serialization::{Deserializer, Serializer};
 
 pub(crate) use errors::ReceiveErrorType;
 pub(crate) use object_safe::{BoxedRng, ObjectSafeRound};
-
-pub use digest;

--- a/manul/src/session.rs
+++ b/manul/src/session.rs
@@ -25,6 +25,3 @@ pub use transcript::{SessionOutcome, SessionReport};
 pub use wire_format::WireFormat;
 
 pub(crate) use echo::EchoRoundError;
-
-pub use digest;
-pub use signature;

--- a/manul/src/tests/partial_echo.rs
+++ b/manul/src/tests/partial_echo.rs
@@ -13,7 +13,7 @@ use serde::{Deserialize, Serialize};
 use crate::{
     dev::{run_sync, BinaryFormat, TestSessionParams, TestSigner, TestVerifier},
     protocol::*,
-    session::signature::Keypair,
+    signature::Keypair,
 };
 
 #[derive(Debug)]

--- a/manul/src/tests/partial_echo.rs
+++ b/manul/src/tests/partial_echo.rs
@@ -12,7 +12,11 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     dev::{run_sync, BinaryFormat, TestSessionParams, TestSigner, TestVerifier},
-    protocol::*,
+    protocol::{
+        Artifact, BoxedRound, Deserializer, DirectMessage, EchoBroadcast, EchoRoundParticipation, EntryPoint,
+        FinalizeOutcome, LocalError, NormalBroadcast, PartyId, Payload, Protocol, ProtocolError, ProtocolMessagePart,
+        ProtocolValidationError, ReceiveError, Round, RoundId, Serializer,
+    },
     signature::Keypair,
 };
 


### PR DESCRIPTION
- Remove `protocol::digest` re-export.
- `digest` and `signature` are now re-exported from the top level instead of `session`.
