### PR TITLE
Pass more info for evidence verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `ProtocolError::verify_messages_constitute_error()` takes a new `guilty_party` argument. ([#76])
 - `Combinator`/`CombinatorEntryPoint` removed in favor of a single `ChainedMarker` trait. ([#76])
 - The `combined_echos` argument to `ProtocolError::verify_messages_constitute_error()` now has a mapping of id to echo instead of just a vector of echos. ([#76])
+- `ProtocolError::verify_messages_constitute_error()` now takes messages and mapping of messages by value. ([#76])
 
 
 [#75]: https://github.com/entropyxyz/manul/pull/75

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Removed `protocol::digest` re-export ([#75]).
 - `digest` and `signature` are now re-exported from the top level instead of `session` ([#75]).
+- `ProtocolError::verify_messages_constitute_error()` takes a new `shared_randomness` argument. ([#76])
 
 
 [#75]: https://github.com/entropyxyz/manul/pull/75
+[#76]: https://github.com/entropyxyz/manul/pull/76
 
 
 ## [0.1.0] - 2024-11-19

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Protocol` and `ProtocolError` are now generic over `Id`. ([#76])
 - `ProtocolError::verify_messages_constitute_error()` takes a new `guilty_party` argument. ([#76])
 - `Combinator`/`CombinatorEntryPoint` removed in favor of a single `ChainedMarker` trait. ([#76])
+- The `combined_echos` argument to `ProtocolError::verify_messages_constitute_error()` now has a mapping of id to echo instead of just a vector of echos. ([#76])
 
 
 [#75]: https://github.com/entropyxyz/manul/pull/75

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed `protocol::digest` re-export ([#75]).
 - `digest` and `signature` are now re-exported from the top level instead of `session` ([#75]).
 - `ProtocolError::verify_messages_constitute_error()` takes a new `shared_randomness` argument. ([#76])
+- `Protocol` and `ProtocolError` are now generic over `Id`. ([#76])
+- `ProtocolError::verify_messages_constitute_error()` takes a new `guilty_party` argument. ([#76])
+- `Combinator`/`CombinatorEntryPoint` removed in favor of a single `ChainedMarker` trait. ([#76])
 
 
 [#75]: https://github.com/entropyxyz/manul/pull/75

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ We try to find the balance between supporting the majority of protocols and keep
 - A protocol consists of several rounds.
 - A round generates messages to send out without any additional external input, then waits for messages from other parties. When it receives enough messages, it can be finalized.
 - On finalization, a round can return the result, halt with an error, or continue to another round.
-- Each round declares a set of parties it sends messages to. Then it can optionally send a direct message to each party in the set, set a regular broadcast to all parties in the set, or send an echo-broadcast to all parties in the set (that is, a broadcast where it is ensured that all parties received the same thing). Any number of these options can be picked.
+- Each round declares a set of parties it sends messages to. Then it can optionally send a direct message to each party in the set, send a regular broadcast to all parties in the set, or send an echo-broadcast to all parties in the set (that is, a broadcast where it is ensured that all parties received the same thing). Any number of these options can be picked.
 
 
 [crate-image]: https://img.shields.io/crates/v/manul.svg

--- a/examples/src/simple.rs
+++ b/examples/src/simple.rs
@@ -61,7 +61,7 @@ impl<Id> ProtocolError<Id> for SimpleProtocolError {
         _echo_broadcasts: &BTreeMap<RoundId, EchoBroadcast>,
         _normal_broadcasts: &BTreeMap<RoundId, NormalBroadcast>,
         _direct_messages: &BTreeMap<RoundId, DirectMessage>,
-        combined_echos: &BTreeMap<RoundId, Vec<EchoBroadcast>>,
+        combined_echos: &BTreeMap<RoundId, BTreeMap<Id, EchoBroadcast>>,
     ) -> Result<(), ProtocolValidationError> {
         match self {
             SimpleProtocolError::Round1InvalidPosition => {
@@ -78,7 +78,7 @@ impl<Id> ProtocolError<Id> for SimpleProtocolError {
                 // Deserialize the echos
                 let _r1_echos = r1_echos_serialized
                     .iter()
-                    .map(|echo| echo.deserialize::<Round1Echo>(deserializer))
+                    .map(|(_id, echo)| echo.deserialize::<Round1Echo>(deserializer))
                     .collect::<Result<Vec<_>, _>>()?;
 
                 // Message contents would be checked here

--- a/examples/src/simple.rs
+++ b/examples/src/simple.rs
@@ -53,6 +53,7 @@ impl ProtocolError for SimpleProtocolError {
     fn verify_messages_constitute_error(
         &self,
         deserializer: &Deserializer,
+        _shared_randomness: &[u8],
         _echo_broadcast: &EchoBroadcast,
         _normal_broadcast: &NormalBroadcast,
         direct_message: &DirectMessage,

--- a/examples/src/simple.rs
+++ b/examples/src/simple.rs
@@ -23,7 +23,7 @@ pub enum SimpleProtocolError {
     Round2InvalidPosition,
 }
 
-impl ProtocolError for SimpleProtocolError {
+impl<Id> ProtocolError<Id> for SimpleProtocolError {
     fn description(&self) -> String {
         format!("{:?}", self)
     }
@@ -53,6 +53,7 @@ impl ProtocolError for SimpleProtocolError {
     fn verify_messages_constitute_error(
         &self,
         deserializer: &Deserializer,
+        _guilty_party: &Id,
         _shared_randomness: &[u8],
         _echo_broadcast: &EchoBroadcast,
         _normal_broadcast: &NormalBroadcast,
@@ -87,7 +88,7 @@ impl ProtocolError for SimpleProtocolError {
     }
 }
 
-impl Protocol for SimpleProtocol {
+impl<Id> Protocol<Id> for SimpleProtocol {
     type Result = u8;
     type ProtocolError = SimpleProtocolError;
 

--- a/examples/src/simple.rs
+++ b/examples/src/simple.rs
@@ -55,13 +55,13 @@ impl<Id> ProtocolError<Id> for SimpleProtocolError {
         deserializer: &Deserializer,
         _guilty_party: &Id,
         _shared_randomness: &[u8],
-        _echo_broadcast: &EchoBroadcast,
-        _normal_broadcast: &NormalBroadcast,
-        direct_message: &DirectMessage,
-        _echo_broadcasts: &BTreeMap<RoundId, EchoBroadcast>,
-        _normal_broadcasts: &BTreeMap<RoundId, NormalBroadcast>,
-        _direct_messages: &BTreeMap<RoundId, DirectMessage>,
-        combined_echos: &BTreeMap<RoundId, BTreeMap<Id, EchoBroadcast>>,
+        _echo_broadcast: EchoBroadcast,
+        _normal_broadcast: NormalBroadcast,
+        direct_message: DirectMessage,
+        _echo_broadcasts: BTreeMap<RoundId, EchoBroadcast>,
+        _normal_broadcasts: BTreeMap<RoundId, NormalBroadcast>,
+        _direct_messages: BTreeMap<RoundId, DirectMessage>,
+        combined_echos: BTreeMap<RoundId, BTreeMap<Id, EchoBroadcast>>,
     ) -> Result<(), ProtocolValidationError> {
         match self {
             SimpleProtocolError::Round1InvalidPosition => {

--- a/examples/src/simple_chain.rs
+++ b/examples/src/simple_chain.rs
@@ -2,10 +2,7 @@ use alloc::collections::BTreeSet;
 use core::fmt::Debug;
 
 use manul::{
-    combinators::{
-        chain::{Chain, ChainedJoin, ChainedProtocol, ChainedSplit},
-        CombinatorEntryPoint,
-    },
+    combinators::chain::{ChainedJoin, ChainedMarker, ChainedProtocol, ChainedSplit},
     protocol::{PartyId, Protocol},
 };
 
@@ -16,7 +13,9 @@ use super::simple::{SimpleProtocol, SimpleProtocolEntryPoint};
 #[derive(Debug)]
 pub struct DoubleSimpleProtocol;
 
-impl ChainedProtocol for DoubleSimpleProtocol {
+impl ChainedMarker for DoubleSimpleProtocol {}
+
+impl<Id> ChainedProtocol<Id> for DoubleSimpleProtocol {
     type Protocol1 = SimpleProtocol;
     type Protocol2 = SimpleProtocol;
 }
@@ -25,14 +24,12 @@ pub struct DoubleSimpleEntryPoint<Id> {
     all_ids: BTreeSet<Id>,
 }
 
+impl<Id> ChainedMarker for DoubleSimpleEntryPoint<Id> {}
+
 impl<Id: PartyId> DoubleSimpleEntryPoint<Id> {
     pub fn new(all_ids: BTreeSet<Id>) -> Self {
         Self { all_ids }
     }
-}
-
-impl<Id> CombinatorEntryPoint for DoubleSimpleEntryPoint<Id> {
-    type Combinator = Chain;
 }
 
 impl<Id> ChainedSplit<Id> for DoubleSimpleEntryPoint<Id>
@@ -60,7 +57,7 @@ where
 {
     type Protocol = DoubleSimpleProtocol;
     type EntryPoint = SimpleProtocolEntryPoint<Id>;
-    fn make_entry_point2(self, _result: <SimpleProtocol as Protocol>::Result) -> Self::EntryPoint {
+    fn make_entry_point2(self, _result: <SimpleProtocol as Protocol<Id>>::Result) -> Self::EntryPoint {
         SimpleProtocolEntryPoint::new(self.all_ids)
     }
 }

--- a/examples/tests/async_runner.rs
+++ b/examples/tests/async_runner.rs
@@ -35,7 +35,7 @@ async fn run_session<P, SP>(
     session: Session<P, SP>,
 ) -> Result<SessionReport<P, SP>, LocalError>
 where
-    P: Protocol,
+    P: Protocol<SP::Verifier>,
     SP: SessionParameters,
 {
     let rng = &mut OsRng;
@@ -194,7 +194,7 @@ async fn message_dispatcher<SP>(
 
 async fn run_nodes<P, SP>(sessions: Vec<Session<P, SP>>) -> Vec<SessionReport<P, SP>>
 where
-    P: Protocol + Send,
+    P: Protocol<SP::Verifier> + Send,
     SP: SessionParameters,
     P::Result: Send,
     SP::Signer: Send,

--- a/manul/benches/empty_rounds.rs
+++ b/manul/benches/empty_rounds.rs
@@ -18,7 +18,7 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug)]
 pub struct EmptyProtocol;
 
-impl Protocol for EmptyProtocol {
+impl<Id> Protocol<Id> for EmptyProtocol {
     type Result = ();
     type ProtocolError = ();
 }

--- a/manul/src/combinators.rs
+++ b/manul/src/combinators.rs
@@ -1,7 +1,4 @@
 //! Combinators operating on protocols.
 
 pub mod chain;
-mod markers;
 pub mod misbehave;
-
-pub use markers::{Combinator, CombinatorEntryPoint};

--- a/manul/src/combinators/chain.rs
+++ b/manul/src/combinators/chain.rs
@@ -51,7 +51,6 @@ use alloc::{
     collections::{BTreeMap, BTreeSet},
     format,
     string::String,
-    vec::Vec,
 };
 use core::fmt::Debug;
 
@@ -112,6 +111,7 @@ where
 
 impl<Id, C> ProtocolError<Id> for ChainedProtocolError<Id, C>
 where
+    Id: Clone,
     C: ChainedProtocol<Id>,
 {
     fn description(&self) -> String {
@@ -177,7 +177,7 @@ where
         echo_broadcasts: &BTreeMap<RoundId, EchoBroadcast>,
         normal_broadcasts: &BTreeMap<RoundId, NormalBroadcast>,
         direct_messages: &BTreeMap<RoundId, DirectMessage>,
-        combined_echos: &BTreeMap<RoundId, Vec<EchoBroadcast>>,
+        combined_echos: &BTreeMap<RoundId, BTreeMap<Id, EchoBroadcast>>,
     ) -> Result<(), ProtocolValidationError> {
         // TODO: the cloning can be avoided if instead we provide a reference to some "transcript API",
         // and can replace it here with a proxy that will remove nesting from round ID's.
@@ -233,7 +233,7 @@ where
 
 impl<Id, C> Protocol<Id> for C
 where
-    Id: 'static,
+    Id: 'static + Clone,
     C: ChainedProtocol<Id> + ChainedMarker,
 {
     type Result = <C::Protocol2 as Protocol<Id>>::Result;

--- a/manul/src/combinators/chain.rs
+++ b/manul/src/combinators/chain.rs
@@ -169,6 +169,7 @@ where
     fn verify_messages_constitute_error(
         &self,
         deserializer: &Deserializer,
+        shared_randomness: &[u8],
         echo_broadcast: &EchoBroadcast,
         normal_broadcast: &NormalBroadcast,
         direct_message: &DirectMessage,
@@ -203,6 +204,7 @@ where
         match self {
             Self::Protocol1(err) => err.verify_messages_constitute_error(
                 deserializer,
+                shared_randomness,
                 echo_broadcast,
                 normal_broadcast,
                 direct_message,
@@ -213,6 +215,7 @@ where
             ),
             Self::Protocol2(err) => err.verify_messages_constitute_error(
                 deserializer,
+                shared_randomness,
                 echo_broadcast,
                 normal_broadcast,
                 direct_message,

--- a/manul/src/combinators/chain.rs
+++ b/manul/src/combinators/chain.rs
@@ -111,7 +111,6 @@ where
 
 impl<Id, C> ProtocolError<Id> for ChainedProtocolError<Id, C>
 where
-    Id: Clone,
     C: ChainedProtocol<Id>,
 {
     fn description(&self) -> String {
@@ -171,33 +170,29 @@ where
         deserializer: &Deserializer,
         guilty_party: &Id,
         shared_randomness: &[u8],
-        echo_broadcast: &EchoBroadcast,
-        normal_broadcast: &NormalBroadcast,
-        direct_message: &DirectMessage,
-        echo_broadcasts: &BTreeMap<RoundId, EchoBroadcast>,
-        normal_broadcasts: &BTreeMap<RoundId, NormalBroadcast>,
-        direct_messages: &BTreeMap<RoundId, DirectMessage>,
-        combined_echos: &BTreeMap<RoundId, BTreeMap<Id, EchoBroadcast>>,
+        echo_broadcast: EchoBroadcast,
+        normal_broadcast: NormalBroadcast,
+        direct_message: DirectMessage,
+        echo_broadcasts: BTreeMap<RoundId, EchoBroadcast>,
+        normal_broadcasts: BTreeMap<RoundId, NormalBroadcast>,
+        direct_messages: BTreeMap<RoundId, DirectMessage>,
+        combined_echos: BTreeMap<RoundId, BTreeMap<Id, EchoBroadcast>>,
     ) -> Result<(), ProtocolValidationError> {
         // TODO: the cloning can be avoided if instead we provide a reference to some "transcript API",
         // and can replace it here with a proxy that will remove nesting from round ID's.
         let echo_broadcasts = echo_broadcasts
-            .clone()
             .into_iter()
             .map(|(round_id, v)| round_id.ungroup().map(|round_id| (round_id, v)))
             .collect::<Result<BTreeMap<_, _>, _>>()?;
         let normal_broadcasts = normal_broadcasts
-            .clone()
             .into_iter()
             .map(|(round_id, v)| round_id.ungroup().map(|round_id| (round_id, v)))
             .collect::<Result<BTreeMap<_, _>, _>>()?;
         let direct_messages = direct_messages
-            .clone()
             .into_iter()
             .map(|(round_id, v)| round_id.ungroup().map(|round_id| (round_id, v)))
             .collect::<Result<BTreeMap<_, _>, _>>()?;
         let combined_echos = combined_echos
-            .clone()
             .into_iter()
             .map(|(round_id, v)| round_id.ungroup().map(|round_id| (round_id, v)))
             .collect::<Result<BTreeMap<_, _>, _>>()?;
@@ -210,10 +205,10 @@ where
                 echo_broadcast,
                 normal_broadcast,
                 direct_message,
-                &echo_broadcasts,
-                &normal_broadcasts,
-                &direct_messages,
-                &combined_echos,
+                echo_broadcasts,
+                normal_broadcasts,
+                direct_messages,
+                combined_echos,
             ),
             Self::Protocol2(err) => err.verify_messages_constitute_error(
                 deserializer,
@@ -222,10 +217,10 @@ where
                 echo_broadcast,
                 normal_broadcast,
                 direct_message,
-                &echo_broadcasts,
-                &normal_broadcasts,
-                &direct_messages,
-                &combined_echos,
+                echo_broadcasts,
+                normal_broadcasts,
+                direct_messages,
+                combined_echos,
             ),
         }
     }
@@ -233,7 +228,7 @@ where
 
 impl<Id, C> Protocol<Id> for C
 where
-    Id: 'static + Clone,
+    Id: 'static,
     C: ChainedProtocol<Id> + ChainedMarker,
 {
     type Result = <C::Protocol2 as Protocol<Id>>::Result;

--- a/manul/src/combinators/markers.rs
+++ b/manul/src/combinators/markers.rs
@@ -1,9 +1,0 @@
-/// A marker trait for protocol combinators.
-pub trait Combinator {}
-
-/// Marks an entry point for a protocol combinator result, so that [`EntryPoint`](`crate::protocol::EntryPoint`)
-/// can be derived automatically for it.
-pub trait CombinatorEntryPoint {
-    /// The type of the combinator.
-    type Combinator: Combinator;
-}

--- a/manul/src/dev/run_sync.rs
+++ b/manul/src/dev/run_sync.rs
@@ -13,7 +13,7 @@ use crate::{
     },
 };
 
-enum State<P: Protocol, SP: SessionParameters> {
+enum State<P: Protocol<SP::Verifier>, SP: SessionParameters> {
     InProgress {
         session: Session<P, SP>,
         accum: RoundAccumulator<P, SP>,
@@ -34,7 +34,7 @@ fn propagate<P, SP>(
     accum: RoundAccumulator<P, SP>,
 ) -> Result<(State<P, SP>, Vec<RoundMessage<SP>>), LocalError>
 where
-    P: Protocol,
+    P: Protocol<SP::Verifier>,
     SP: SessionParameters,
 {
     let mut messages = Vec::new();
@@ -168,12 +168,12 @@ where
 
 /// The result of a protocol execution on a set of nodes.
 #[derive(Debug)]
-pub struct ExecutionResult<P: Protocol, SP: SessionParameters> {
+pub struct ExecutionResult<P: Protocol<SP::Verifier>, SP: SessionParameters> {
     pub reports: BTreeMap<SP::Verifier, SessionReport<P, SP>>,
 }
 impl<P, SP> ExecutionResult<P, SP>
 where
-    P: Protocol,
+    P: Protocol<SP::Verifier>,
     SP: SessionParameters,
 {
     pub fn results(self) -> Result<BTreeMap<SP::Verifier, P::Result>, String> {

--- a/manul/src/protocol/errors.rs
+++ b/manul/src/protocol/errors.rs
@@ -30,10 +30,10 @@ impl RemoteError {
 
 /// An error that can be returned from [`Round::receive_message`](`super::Round::receive_message`).
 #[derive(Debug)]
-pub struct ReceiveError<Id, P: Protocol>(pub(crate) ReceiveErrorType<Id, P>);
+pub struct ReceiveError<Id, P: Protocol<Id>>(pub(crate) ReceiveErrorType<Id, P>);
 
 #[derive(Debug)]
-pub(crate) enum ReceiveErrorType<Id, P: Protocol> {
+pub(crate) enum ReceiveErrorType<Id, P: Protocol<Id>> {
     /// A local error, indicating an implemenation bug or a misuse by the upper layer.
     Local(LocalError),
     /// The given direct message cannot be deserialized.
@@ -53,7 +53,7 @@ pub(crate) enum ReceiveErrorType<Id, P: Protocol> {
     Echo(Box<EchoRoundError<Id>>),
 }
 
-impl<Id, P: Protocol> ReceiveError<Id, P> {
+impl<Id, P: Protocol<Id>> ReceiveError<Id, P> {
     /// A local error, indicating an implemenation bug or a misuse by the upper layer.
     pub fn local(message: impl Into<String>) -> Self {
         Self(ReceiveErrorType::Local(LocalError::new(message.into())))
@@ -73,17 +73,17 @@ impl<Id, P: Protocol> ReceiveError<Id, P> {
     pub(crate) fn map<T, F>(self, f: F) -> ReceiveError<Id, T>
     where
         F: Fn(P::ProtocolError) -> T::ProtocolError,
-        T: Protocol,
+        T: Protocol<Id>,
     {
         ReceiveError(self.0.map::<T, F>(f))
     }
 }
 
-impl<Id, P: Protocol> ReceiveErrorType<Id, P> {
+impl<Id, P: Protocol<Id>> ReceiveErrorType<Id, P> {
     pub(crate) fn map<T, F>(self, f: F) -> ReceiveErrorType<Id, T>
     where
         F: Fn(P::ProtocolError) -> T::ProtocolError,
-        T: Protocol,
+        T: Protocol<Id>,
     {
         match self {
             Self::Local(err) => ReceiveErrorType::Local(err),
@@ -99,7 +99,7 @@ impl<Id, P: Protocol> ReceiveErrorType<Id, P> {
 
 impl<Id, P> From<LocalError> for ReceiveError<Id, P>
 where
-    P: Protocol,
+    P: Protocol<Id>,
 {
     fn from(error: LocalError) -> Self {
         Self(ReceiveErrorType::Local(error))
@@ -108,7 +108,7 @@ where
 
 impl<Id, P> From<RemoteError> for ReceiveError<Id, P>
 where
-    P: Protocol,
+    P: Protocol<Id>,
 {
     fn from(error: RemoteError) -> Self {
         Self(ReceiveErrorType::Unprovable(error))
@@ -117,7 +117,7 @@ where
 
 impl<Id, P> From<EchoRoundError<Id>> for ReceiveError<Id, P>
 where
-    P: Protocol,
+    P: Protocol<Id>,
 {
     fn from(error: EchoRoundError<Id>) -> Self {
         Self(ReceiveErrorType::Echo(Box::new(error)))
@@ -126,7 +126,7 @@ where
 
 impl<Id, P> From<DirectMessageError> for ReceiveError<Id, P>
 where
-    P: Protocol,
+    P: Protocol<Id>,
 {
     fn from(error: DirectMessageError) -> Self {
         Self(ReceiveErrorType::InvalidDirectMessage(error))
@@ -135,7 +135,7 @@ where
 
 impl<Id, P> From<EchoBroadcastError> for ReceiveError<Id, P>
 where
-    P: Protocol,
+    P: Protocol<Id>,
 {
     fn from(error: EchoBroadcastError) -> Self {
         Self(ReceiveErrorType::InvalidEchoBroadcast(error))
@@ -144,7 +144,7 @@ where
 
 impl<Id, P> From<NormalBroadcastError> for ReceiveError<Id, P>
 where
-    P: Protocol,
+    P: Protocol<Id>,
 {
     fn from(error: NormalBroadcastError) -> Self {
         Self(ReceiveErrorType::InvalidNormalBroadcast(error))

--- a/manul/src/protocol/object_safe.rs
+++ b/manul/src/protocol/object_safe.rs
@@ -40,7 +40,7 @@ impl RngCore for BoxedRng<'_> {
 // (which is what all cryptographic libraries generally take), it cannot be object-safe.
 // Thus we have to add this crate-private object-safe layer on top of `Round`.
 pub(crate) trait ObjectSafeRound<Id: PartyId>: 'static + Debug + Send + Sync {
-    type Protocol: Protocol;
+    type Protocol: Protocol<Id>;
 
     fn id(&self) -> RoundId;
 
@@ -217,12 +217,12 @@ where
 /// A wrapped new round that may be returned by [`Round::finalize`]
 /// or [`EntryPoint::make_round`](`crate::protocol::EntryPoint::make_round`).
 #[derive_where::derive_where(Debug)]
-pub struct BoxedRound<Id: PartyId, P: Protocol> {
+pub struct BoxedRound<Id: PartyId, P: Protocol<Id>> {
     wrapped: bool,
     round: Box<dyn ObjectSafeRound<Id, Protocol = P>>,
 }
 
-impl<Id: PartyId, P: Protocol> BoxedRound<Id, P> {
+impl<Id: PartyId, P: Protocol<Id>> BoxedRound<Id, P> {
     /// Wraps an object implementing the dynamic round trait ([`Round`](`crate::protocol::Round`)).
     pub fn new_dynamic<R: Round<Id, Protocol = P>>(round: R) -> Self {
         Self {

--- a/manul/src/protocol/round.rs
+++ b/manul/src/protocol/round.rs
@@ -235,13 +235,13 @@ pub trait ProtocolError<Id>: Debug + Clone + Send + Serialize + for<'de> Deseria
         deserializer: &Deserializer,
         guilty_party: &Id,
         shared_randomness: &[u8],
-        echo_broadcast: &EchoBroadcast,
-        normal_broadcast: &NormalBroadcast,
-        direct_message: &DirectMessage,
-        echo_broadcasts: &BTreeMap<RoundId, EchoBroadcast>,
-        normal_broadcasts: &BTreeMap<RoundId, NormalBroadcast>,
-        direct_messages: &BTreeMap<RoundId, DirectMessage>,
-        combined_echos: &BTreeMap<RoundId, BTreeMap<Id, EchoBroadcast>>,
+        echo_broadcast: EchoBroadcast,
+        normal_broadcast: NormalBroadcast,
+        direct_message: DirectMessage,
+        echo_broadcasts: BTreeMap<RoundId, EchoBroadcast>,
+        normal_broadcasts: BTreeMap<RoundId, NormalBroadcast>,
+        direct_messages: BTreeMap<RoundId, DirectMessage>,
+        combined_echos: BTreeMap<RoundId, BTreeMap<Id, EchoBroadcast>>,
     ) -> Result<(), ProtocolValidationError>;
 }
 
@@ -257,13 +257,13 @@ impl<Id> ProtocolError<Id> for () {
         _deserializer: &Deserializer,
         _guilty_party: &Id,
         _shared_randomness: &[u8],
-        _echo_broadcast: &EchoBroadcast,
-        _normal_broadcast: &NormalBroadcast,
-        _direct_message: &DirectMessage,
-        _echo_broadcasts: &BTreeMap<RoundId, EchoBroadcast>,
-        _normal_broadcasts: &BTreeMap<RoundId, NormalBroadcast>,
-        _direct_messages: &BTreeMap<RoundId, DirectMessage>,
-        _combined_echos: &BTreeMap<RoundId, BTreeMap<Id, EchoBroadcast>>,
+        _echo_broadcast: EchoBroadcast,
+        _normal_broadcast: NormalBroadcast,
+        _direct_message: DirectMessage,
+        _echo_broadcasts: BTreeMap<RoundId, EchoBroadcast>,
+        _normal_broadcasts: BTreeMap<RoundId, NormalBroadcast>,
+        _direct_messages: BTreeMap<RoundId, DirectMessage>,
+        _combined_echos: BTreeMap<RoundId, BTreeMap<Id, EchoBroadcast>>,
     ) -> Result<(), ProtocolValidationError> {
         panic!("Attempt to use an empty error type in an evidence. This is a bug in the protocol implementation.")
     }

--- a/manul/src/protocol/round.rs
+++ b/manul/src/protocol/round.rs
@@ -234,6 +234,7 @@ pub trait ProtocolError: Debug + Clone + Send + Serialize + for<'de> Deserialize
     fn verify_messages_constitute_error(
         &self,
         deserializer: &Deserializer,
+        shared_randomness: &[u8],
         echo_broadcast: &EchoBroadcast,
         normal_broadcast: &NormalBroadcast,
         direct_message: &DirectMessage,
@@ -254,6 +255,7 @@ impl ProtocolError for () {
     fn verify_messages_constitute_error(
         &self,
         _deserializer: &Deserializer,
+        _shared_randomness: &[u8],
         _echo_broadcast: &EchoBroadcast,
         _normal_broadcast: &NormalBroadcast,
         _direct_message: &DirectMessage,

--- a/manul/src/protocol/round.rs
+++ b/manul/src/protocol/round.rs
@@ -3,7 +3,6 @@ use alloc::{
     collections::{BTreeMap, BTreeSet},
     format,
     string::String,
-    vec::Vec,
 };
 use core::{
     any::Any,
@@ -242,7 +241,7 @@ pub trait ProtocolError<Id>: Debug + Clone + Send + Serialize + for<'de> Deseria
         echo_broadcasts: &BTreeMap<RoundId, EchoBroadcast>,
         normal_broadcasts: &BTreeMap<RoundId, NormalBroadcast>,
         direct_messages: &BTreeMap<RoundId, DirectMessage>,
-        combined_echos: &BTreeMap<RoundId, Vec<EchoBroadcast>>,
+        combined_echos: &BTreeMap<RoundId, BTreeMap<Id, EchoBroadcast>>,
     ) -> Result<(), ProtocolValidationError>;
 }
 
@@ -264,7 +263,7 @@ impl<Id> ProtocolError<Id> for () {
         _echo_broadcasts: &BTreeMap<RoundId, EchoBroadcast>,
         _normal_broadcasts: &BTreeMap<RoundId, NormalBroadcast>,
         _direct_messages: &BTreeMap<RoundId, DirectMessage>,
-        _combined_echos: &BTreeMap<RoundId, Vec<EchoBroadcast>>,
+        _combined_echos: &BTreeMap<RoundId, BTreeMap<Id, EchoBroadcast>>,
     ) -> Result<(), ProtocolValidationError> {
         panic!("Attempt to use an empty error type in an evidence. This is a bug in the protocol implementation.")
     }

--- a/manul/src/session/echo.rs
+++ b/manul/src/session/echo.rs
@@ -73,7 +73,7 @@ pub(crate) struct EchoRoundMessage<SP: SessionParameters> {
 /// participants. The execution layer of the protocol guarantees that all participants have received
 /// the messages.
 #[derive_where::derive_where(Debug)]
-pub struct EchoRound<P: Protocol, SP: SessionParameters> {
+pub struct EchoRound<P: Protocol<SP::Verifier>, SP: SessionParameters> {
     verifier: SP::Verifier,
     echo_broadcasts: BTreeMap<SP::Verifier, SignedMessagePart<EchoBroadcast>>,
     echo_round_info: EchoRoundInfo<SP::Verifier>,
@@ -84,7 +84,7 @@ pub struct EchoRound<P: Protocol, SP: SessionParameters> {
 
 impl<P, SP> EchoRound<P, SP>
 where
-    P: Protocol,
+    P: Protocol<SP::Verifier>,
     SP: SessionParameters,
 {
     pub fn new(
@@ -132,7 +132,7 @@ where
 
 impl<P, SP> Round<SP::Verifier> for EchoRound<P, SP>
 where
-    P: Protocol,
+    P: Protocol<SP::Verifier>,
     SP: SessionParameters,
 {
     type Protocol = P;

--- a/manul/src/session/evidence.rs
+++ b/manul/src/session/evidence.rs
@@ -549,6 +549,7 @@ where
 
         Ok(self.error.verify_messages_constitute_error(
             deserializer,
+            session_id.as_ref(),
             &verified_echo_broadcast,
             &verified_normal_broadcast,
             &verified_direct_message,

--- a/manul/src/session/evidence.rs
+++ b/manul/src/session/evidence.rs
@@ -439,7 +439,7 @@ where
     {
         let session_id = self.direct_message.metadata().session_id();
 
-        let verified_direct_message = self.direct_message.clone().verify::<SP>(verifier)?.payload().clone();
+        let verified_direct_message = self.direct_message.clone().verify::<SP>(verifier)?.into_payload();
 
         let mut verified_direct_messages = BTreeMap::new();
         for (round_id, direct_message) in self.direct_messages.iter() {
@@ -450,10 +450,10 @@ where
                     "Invalid attached message metadata".into(),
                 ));
             }
-            verified_direct_messages.insert(round_id.clone(), verified_direct_message.payload().clone());
+            verified_direct_messages.insert(round_id.clone(), verified_direct_message.into_payload());
         }
 
-        let verified_echo_broadcast = self.echo_broadcast.clone().verify::<SP>(verifier)?.payload().clone();
+        let verified_echo_broadcast = self.echo_broadcast.clone().verify::<SP>(verifier)?.into_payload();
         if self.echo_broadcast.metadata().session_id() != session_id
             || self.echo_broadcast.metadata().round_id() != self.direct_message.metadata().round_id()
         {
@@ -462,7 +462,7 @@ where
             ));
         }
 
-        let verified_normal_broadcast = self.normal_broadcast.clone().verify::<SP>(verifier)?.payload().clone();
+        let verified_normal_broadcast = self.normal_broadcast.clone().verify::<SP>(verifier)?.into_payload();
         if self.normal_broadcast.metadata().session_id() != session_id
             || self.normal_broadcast.metadata().round_id() != self.direct_message.metadata().round_id()
         {
@@ -480,7 +480,7 @@ where
                     "Invalid attached message metadata".into(),
                 ));
             }
-            verified_echo_broadcasts.insert(round_id.clone(), verified_echo_broadcast.payload().clone());
+            verified_echo_broadcasts.insert(round_id.clone(), verified_echo_broadcast.into_payload());
         }
 
         let mut verified_normal_broadcasts = BTreeMap::new();
@@ -492,7 +492,7 @@ where
                     "Invalid attached message metadata".into(),
                 ));
             }
-            verified_normal_broadcasts.insert(round_id.clone(), verified_normal_broadcast.payload().clone());
+            verified_normal_broadcasts.insert(round_id.clone(), verified_normal_broadcast.into_payload());
         }
 
         let mut combined_echos = BTreeMap::new();
@@ -517,7 +517,7 @@ where
                         "Invalid attached message metadata".into(),
                     ));
                 }
-                verified_echo_set.insert(other_verifier.clone(), verified_echo_broadcast.payload().clone());
+                verified_echo_set.insert(other_verifier.clone(), verified_echo_broadcast.into_payload());
             }
             combined_echos.insert(round_id.clone(), verified_echo_set);
         }

--- a/manul/src/session/evidence.rs
+++ b/manul/src/session/evidence.rs
@@ -2,7 +2,6 @@ use alloc::{
     collections::BTreeMap,
     format,
     string::{String, ToString},
-    vec::Vec,
 };
 use core::fmt::Debug;
 
@@ -431,6 +430,7 @@ struct ProtocolEvidence<Id, P: Protocol<Id>> {
 
 impl<Id, P> ProtocolEvidence<Id, P>
 where
+    Id: Clone + Ord,
     P: Protocol<Id>,
 {
     fn verify<SP>(&self, verifier: &SP::Verifier, deserializer: &Deserializer) -> Result<(), EvidenceError>
@@ -508,7 +508,7 @@ where
                 .payload()
                 .deserialize::<EchoRoundMessage<SP>>(deserializer)?;
 
-            let mut verified_echo_set = Vec::new();
+            let mut verified_echo_set = BTreeMap::new();
             for (other_verifier, echo_broadcast) in echo_set.echo_broadcasts.iter() {
                 let verified_echo_broadcast = echo_broadcast.clone().verify::<SP>(other_verifier)?;
                 let metadata = verified_echo_broadcast.metadata();
@@ -517,7 +517,7 @@ where
                         "Invalid attached message metadata".into(),
                     ));
                 }
-                verified_echo_set.push(verified_echo_broadcast.payload().clone());
+                verified_echo_set.insert(other_verifier.clone(), verified_echo_broadcast.payload().clone());
             }
             combined_echos.insert(round_id.clone(), verified_echo_set);
         }

--- a/manul/src/session/evidence.rs
+++ b/manul/src/session/evidence.rs
@@ -526,13 +526,13 @@ where
             deserializer,
             verifier,
             session_id.as_ref(),
-            &verified_echo_broadcast,
-            &verified_normal_broadcast,
-            &verified_direct_message,
-            &verified_echo_broadcasts,
-            &verified_normal_broadcasts,
-            &verified_direct_messages,
-            &combined_echos,
+            verified_echo_broadcast,
+            verified_normal_broadcast,
+            verified_direct_message,
+            verified_echo_broadcasts,
+            verified_normal_broadcasts,
+            verified_direct_messages,
+            combined_echos,
         )?)
     }
 }

--- a/manul/src/session/message.rs
+++ b/manul/src/session/message.rs
@@ -167,6 +167,10 @@ impl<M> VerifiedMessagePart<M> {
         &self.message_with_metadata.message
     }
 
+    pub(crate) fn into_payload(self) -> M {
+        self.message_with_metadata.message
+    }
+
     pub fn into_unverified(self) -> SignedMessagePart<M> {
         SignedMessagePart {
             signature: self.signature,

--- a/manul/src/tests/partial_echo.rs
+++ b/manul/src/tests/partial_echo.rs
@@ -47,7 +47,7 @@ impl<Id: PartyId> ProtocolError<Id> for PartialEchoProtocolError<Id> {
         _echo_broadcasts: &BTreeMap<RoundId, EchoBroadcast>,
         _normal_broadcasts: &BTreeMap<RoundId, NormalBroadcast>,
         _direct_messages: &BTreeMap<RoundId, DirectMessage>,
-        _combined_echos: &BTreeMap<RoundId, Vec<EchoBroadcast>>,
+        _combined_echos: &BTreeMap<RoundId, BTreeMap<Id, EchoBroadcast>>,
     ) -> Result<(), ProtocolValidationError> {
         unimplemented!()
     }

--- a/manul/src/tests/partial_echo.rs
+++ b/manul/src/tests/partial_echo.rs
@@ -41,13 +41,13 @@ impl<Id: PartyId> ProtocolError<Id> for PartialEchoProtocolError<Id> {
         _deserializer: &Deserializer,
         _guilty_party: &Id,
         _shared_randomness: &[u8],
-        _echo_broadcast: &EchoBroadcast,
-        _normal_broadcast: &NormalBroadcast,
-        _direct_message: &DirectMessage,
-        _echo_broadcasts: &BTreeMap<RoundId, EchoBroadcast>,
-        _normal_broadcasts: &BTreeMap<RoundId, NormalBroadcast>,
-        _direct_messages: &BTreeMap<RoundId, DirectMessage>,
-        _combined_echos: &BTreeMap<RoundId, BTreeMap<Id, EchoBroadcast>>,
+        _echo_broadcast: EchoBroadcast,
+        _normal_broadcast: NormalBroadcast,
+        _direct_message: DirectMessage,
+        _echo_broadcasts: BTreeMap<RoundId, EchoBroadcast>,
+        _normal_broadcasts: BTreeMap<RoundId, NormalBroadcast>,
+        _direct_messages: BTreeMap<RoundId, DirectMessage>,
+        _combined_echos: BTreeMap<RoundId, BTreeMap<Id, EchoBroadcast>>,
     ) -> Result<(), ProtocolValidationError> {
         unimplemented!()
     }

--- a/manul/src/tests/partial_echo.rs
+++ b/manul/src/tests/partial_echo.rs
@@ -39,6 +39,7 @@ impl ProtocolError for PartialEchoProtocolError {
     fn verify_messages_constitute_error(
         &self,
         _deserializer: &Deserializer,
+        _shared_randomness: &[u8],
         _echo_broadcast: &EchoBroadcast,
         _normal_broadcast: &NormalBroadcast,
         _direct_message: &DirectMessage,


### PR DESCRIPTION
- Pass `shared_randomness` to `ProtocolError::verify_messages_constitute_error()`.
- Pass `guilty_party` to `verify_messages_constitute_error()` (this is necessary since it is used as a part of the entry data for ZK proofs).
- The above item causes a bit of a chain reaction, since now `ProtocolError` needs to be generic over `Id`, which means `Protocol` needs to be generic over `Id`, with the corresponding changes in all generic bounds throughout the crate.
- Remove `Combinator`/`CombinatorEntryPoint` and replace it with a `ChainedMarker` trait, which works just as well.
- The `combined_echos` argument to `verify_messages_constitute_error()` now has a mapping of id to echo instead of just a vector of echos.
- `verify_messages_constitute_error()` now takes messages and mapping of messages by value.