### PR TITLE
API adjustments for CGGMP'24

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Message parts in `Round::receive_message()` and `ProtocolError::verify_messages_constitute_error()` are bundled in `ProtocolMessage`. ([#79])
 - `RoundId`s are passed by reference in public methods since they are not `Copy`. ([#79])
 - Using a single `ProtocolError::required_messages()` instead of multiple methods. ([#79])
+- `Protocol::verify_*_is_invalid()` are now mandatory to implement. ([#79])
 
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The `combined_echos` argument to `ProtocolError::verify_messages_constitute_error()` now has a mapping of id to echo instead of just a vector of echos. ([#76])
 - `ProtocolError::verify_messages_constitute_error()` now takes messages and mapping of messages by value. ([#76])
 - Removed `ProtocolError::description()`, using `Display` impl instead. ([#79])
+- Added `ProtocolError::AssociatedData` type, and a corresponding argument to `ProtocolError::verify_messages_constitute_error()` and `Evidence::verify()`. ([#79])
 
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,12 +16,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Combinator`/`CombinatorEntryPoint` removed in favor of a single `ChainedMarker` trait. ([#76])
 - The `combined_echos` argument to `ProtocolError::verify_messages_constitute_error()` now has a mapping of id to echo instead of just a vector of echos. ([#76])
 - `ProtocolError::verify_messages_constitute_error()` now takes messages and mapping of messages by value. ([#76])
+- Removed `ProtocolError::description()`, using `Display` impl instead. ([#79])
 
 
 ### Added
 
 - `impl From<NormalBroadcastError> for ProtocolValidationError` (to match what already exists for other messages). ([#77])
 - Exposed `dev::ExecutionResult`. ([#79])
+- `NoProtocolErrors` stub type to indicate that the protocol does not generate any provable errors. ([#79])
 
 
 [#75]: https://github.com/entropyxyz/manul/pull/75

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed `ProtocolError::description()`, using `Display` impl instead. ([#79])
 - Added `ProtocolError::AssociatedData` type, and a corresponding argument to `ProtocolError::verify_messages_constitute_error()` and `Evidence::verify()`. ([#79])
 - Message parts in `Round::receive_message()` and `ProtocolError::verify_messages_constitute_error()` are bundled in `ProtocolMessage`. ([#79])
+- `RoundId`s are passed by reference in public methods since they are not `Copy`. ([#79])
+- Using a single `ProtocolError::required_messages()` instead of multiple methods. ([#79])
 
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `ProtocolError::verify_messages_constitute_error()` now takes messages and mapping of messages by value. ([#76])
 - Removed `ProtocolError::description()`, using `Display` impl instead. ([#79])
 - Added `ProtocolError::AssociatedData` type, and a corresponding argument to `ProtocolError::verify_messages_constitute_error()` and `Evidence::verify()`. ([#79])
+- Message parts in `Round::receive_message()` and `ProtocolError::verify_messages_constitute_error()` are bundled in `ProtocolMessage`. ([#79])
 
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,11 +21,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - `impl From<NormalBroadcastError> for ProtocolValidationError` (to match what already exists for other messages). ([#77])
+- Exposed `dev::ExecutionResult`. ([#79])
 
 
 [#75]: https://github.com/entropyxyz/manul/pull/75
 [#76]: https://github.com/entropyxyz/manul/pull/76
 [#77]: https://github.com/entropyxyz/manul/pull/77
+[#79]: https://github.com/entropyxyz/manul/pull/79
 
 
 ## [0.1.0] - 2024-11-19

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -577,6 +577,7 @@ name = "manul-example"
 version = "0.0.0"
 dependencies = [
  "digest",
+ "displaydoc",
  "manul",
  "postcard",
  "rand",

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -15,6 +15,7 @@ serde = "1"
 sha3 = "0.10"
 rand_core = "0.6"
 tracing = "0.1"
+displaydoc = "0.2"
 
 [dev-dependencies]
 tokio = { version = "1", features = ["rt", "sync", "time", "macros"] }

--- a/examples/src/simple.rs
+++ b/examples/src/simple.rs
@@ -1,8 +1,4 @@
-use alloc::{
-    collections::{BTreeMap, BTreeSet},
-    format,
-    string::String,
-};
+use alloc::collections::{BTreeMap, BTreeSet};
 use core::fmt::Debug;
 
 use manul::protocol::{
@@ -17,17 +13,16 @@ use tracing::debug;
 #[derive(Debug)]
 pub struct SimpleProtocol;
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(displaydoc::Display, Debug, Clone, Serialize, Deserialize)]
+/// An example error.
 pub enum SimpleProtocolError {
+    /// Invalid position in Round 1.
     Round1InvalidPosition,
+    /// Invalid position in Round 2.
     Round2InvalidPosition,
 }
 
 impl<Id> ProtocolError<Id> for SimpleProtocolError {
-    fn description(&self) -> String {
-        format!("{:?}", self)
-    }
-
     fn required_direct_messages(&self) -> BTreeSet<RoundId> {
         match self {
             Self::Round1InvalidPosition => BTreeSet::new(),

--- a/examples/src/simple.rs
+++ b/examples/src/simple.rs
@@ -101,6 +101,18 @@ impl<Id> Protocol<Id> for SimpleProtocol {
             _ => Err(MessageValidationError::InvalidEvidence("Invalid round number".into())),
         }
     }
+
+    fn verify_normal_broadcast_is_invalid(
+        _deserializer: &Deserializer,
+        round_id: &RoundId,
+        message: &NormalBroadcast,
+    ) -> Result<(), MessageValidationError> {
+        if round_id == &RoundId::new(1) || round_id == &RoundId::new(2) {
+            message.verify_is_some()
+        } else {
+            Err(MessageValidationError::InvalidEvidence("Invalid round number".into()))
+        }
+    }
 }
 
 #[derive(Debug)]

--- a/examples/src/simple.rs
+++ b/examples/src/simple.rs
@@ -23,6 +23,8 @@ pub enum SimpleProtocolError {
 }
 
 impl<Id> ProtocolError<Id> for SimpleProtocolError {
+    type AssociatedData = ();
+
     fn required_direct_messages(&self) -> BTreeSet<RoundId> {
         match self {
             Self::Round1InvalidPosition => BTreeSet::new(),
@@ -50,6 +52,7 @@ impl<Id> ProtocolError<Id> for SimpleProtocolError {
         deserializer: &Deserializer,
         _guilty_party: &Id,
         _shared_randomness: &[u8],
+        _associated_data: &Self::AssociatedData,
         _echo_broadcast: EchoBroadcast,
         _normal_broadcast: NormalBroadcast,
         direct_message: DirectMessage,

--- a/examples/src/simple_malicious.rs
+++ b/examples/src/simple_malicious.rs
@@ -106,8 +106,8 @@ fn serialized_garbage() {
     let report1 = reports.remove(&v1).unwrap();
     let report2 = reports.remove(&v2).unwrap();
 
-    assert!(report1.provable_errors[&v0].verify().is_ok());
-    assert!(report2.provable_errors[&v0].verify().is_ok());
+    assert!(report1.provable_errors[&v0].verify(&()).is_ok());
+    assert!(report2.provable_errors[&v0].verify(&()).is_ok());
 }
 
 #[test]
@@ -145,8 +145,8 @@ fn attributable_failure() {
     let report1 = reports.remove(&v1).unwrap();
     let report2 = reports.remove(&v2).unwrap();
 
-    assert!(report1.provable_errors[&v0].verify().is_ok());
-    assert!(report2.provable_errors[&v0].verify().is_ok());
+    assert!(report1.provable_errors[&v0].verify(&()).is_ok());
+    assert!(report2.provable_errors[&v0].verify(&()).is_ok());
 }
 
 #[test]
@@ -184,6 +184,6 @@ fn attributable_failure_round2() {
     let report1 = reports.remove(&v1).unwrap();
     let report2 = reports.remove(&v2).unwrap();
 
-    assert!(report1.provable_errors[&v0].verify().is_ok());
-    assert!(report2.provable_errors[&v0].verify().is_ok());
+    assert!(report1.provable_errors[&v0].verify(&()).is_ok());
+    assert!(report2.provable_errors[&v0].verify(&()).is_ok());
 }

--- a/manul/benches/empty_rounds.rs
+++ b/manul/benches/empty_rounds.rs
@@ -8,7 +8,7 @@ use manul::{
     dev::{run_sync, BinaryFormat, TestSessionParams, TestSigner},
     protocol::{
         Artifact, BoxedRound, Deserializer, DirectMessage, EchoBroadcast, EntryPoint, FinalizeOutcome, LocalError,
-        NoProtocolErrors, NormalBroadcast, PartyId, Payload, Protocol, ProtocolMessagePart, ReceiveError, Round,
+        NoProtocolErrors, PartyId, Payload, Protocol, ProtocolMessage, ProtocolMessagePart, ReceiveError, Round,
         RoundId, Serializer,
     },
     signature::Keypair,
@@ -113,17 +113,19 @@ impl<Id: PartyId> Round<Id> for EmptyRound<Id> {
         _rng: &mut impl CryptoRngCore,
         deserializer: &Deserializer,
         _from: &Id,
-        echo_broadcast: EchoBroadcast,
-        normal_broadcast: NormalBroadcast,
-        direct_message: DirectMessage,
+        message: ProtocolMessage,
     ) -> Result<Payload, ReceiveError<Id, Self::Protocol>> {
         if self.inputs.echo {
-            let _echo_broadcast = echo_broadcast.deserialize::<Round1EchoBroadcast>(deserializer)?;
+            let _echo_broadcast = message
+                .echo_broadcast
+                .deserialize::<Round1EchoBroadcast>(deserializer)?;
         } else {
-            echo_broadcast.assert_is_none()?;
+            message.echo_broadcast.assert_is_none()?;
         }
-        normal_broadcast.assert_is_none()?;
-        let _direct_message = direct_message.deserialize::<Round1DirectMessage>(deserializer)?;
+        message.normal_broadcast.assert_is_none()?;
+        let _direct_message = message
+            .direct_message
+            .deserialize::<Round1DirectMessage>(deserializer)?;
         Ok(Payload::new(Round1Payload))
     }
 

--- a/manul/benches/empty_rounds.rs
+++ b/manul/benches/empty_rounds.rs
@@ -8,7 +8,8 @@ use manul::{
     dev::{run_sync, BinaryFormat, TestSessionParams, TestSigner},
     protocol::{
         Artifact, BoxedRound, Deserializer, DirectMessage, EchoBroadcast, EntryPoint, FinalizeOutcome, LocalError,
-        NormalBroadcast, PartyId, Payload, Protocol, ProtocolMessagePart, ReceiveError, Round, RoundId, Serializer,
+        NoProtocolErrors, NormalBroadcast, PartyId, Payload, Protocol, ProtocolMessagePart, ReceiveError, Round,
+        RoundId, Serializer,
     },
     signature::Keypair,
 };
@@ -20,7 +21,7 @@ pub struct EmptyProtocol;
 
 impl<Id> Protocol<Id> for EmptyProtocol {
     type Result = ();
-    type ProtocolError = ();
+    type ProtocolError = NoProtocolErrors;
 }
 
 #[derive(Debug)]

--- a/manul/benches/empty_rounds.rs
+++ b/manul/benches/empty_rounds.rs
@@ -8,8 +8,8 @@ use manul::{
     dev::{run_sync, BinaryFormat, TestSessionParams, TestSigner},
     protocol::{
         Artifact, BoxedRound, Deserializer, DirectMessage, EchoBroadcast, EntryPoint, FinalizeOutcome, LocalError,
-        NoProtocolErrors, PartyId, Payload, Protocol, ProtocolMessage, ProtocolMessagePart, ReceiveError, Round,
-        RoundId, Serializer,
+        MessageValidationError, NoProtocolErrors, NormalBroadcast, PartyId, Payload, Protocol, ProtocolMessage,
+        ProtocolMessagePart, ReceiveError, Round, RoundId, Serializer,
     },
     signature::Keypair,
 };
@@ -22,6 +22,30 @@ pub struct EmptyProtocol;
 impl<Id> Protocol<Id> for EmptyProtocol {
     type Result = ();
     type ProtocolError = NoProtocolErrors;
+
+    fn verify_direct_message_is_invalid(
+        _deserializer: &Deserializer,
+        _round_id: &RoundId,
+        _message: &DirectMessage,
+    ) -> Result<(), MessageValidationError> {
+        unimplemented!()
+    }
+
+    fn verify_echo_broadcast_is_invalid(
+        _deserializer: &Deserializer,
+        _round_id: &RoundId,
+        _message: &EchoBroadcast,
+    ) -> Result<(), MessageValidationError> {
+        unimplemented!()
+    }
+
+    fn verify_normal_broadcast_is_invalid(
+        _deserializer: &Deserializer,
+        _round_id: &RoundId,
+        _message: &NormalBroadcast,
+    ) -> Result<(), MessageValidationError> {
+        unimplemented!()
+    }
 }
 
 #[derive(Debug)]

--- a/manul/src/combinators/chain.rs
+++ b/manul/src/combinators/chain.rs
@@ -181,8 +181,6 @@ where
         direct_messages: BTreeMap<RoundId, DirectMessage>,
         combined_echos: BTreeMap<RoundId, BTreeMap<Id, EchoBroadcast>>,
     ) -> Result<(), ProtocolValidationError> {
-        // TODO: the cloning can be avoided if instead we provide a reference to some "transcript API",
-        // and can replace it here with a proxy that will remove nesting from round ID's.
         let echo_broadcasts = echo_broadcasts
             .into_iter()
             .map(|(round_id, v)| round_id.ungroup().map(|round_id| (round_id, v)))

--- a/manul/src/combinators/chain.rs
+++ b/manul/src/combinators/chain.rs
@@ -49,10 +49,8 @@ Usage:
 use alloc::{
     boxed::Box,
     collections::{BTreeMap, BTreeSet},
-    format,
-    string::String,
 };
-use core::fmt::Debug;
+use core::fmt::{self, Debug};
 
 use rand_core::CryptoRngCore;
 use serde::{Deserialize, Serialize};
@@ -96,6 +94,18 @@ where
     Protocol2(<C::Protocol2 as Protocol<Id>>::ProtocolError),
 }
 
+impl<Id, C> fmt::Display for ChainedProtocolError<Id, C>
+where
+    C: ChainedProtocol<Id>,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
+        match self {
+            Self::Protocol1(err) => write!(f, "Protocol 1: {err}"),
+            Self::Protocol2(err) => write!(f, "Protocol 2: {err}"),
+        }
+    }
+}
+
 impl<Id, C> ChainedProtocolError<Id, C>
 where
     C: ChainedProtocol<Id>,
@@ -113,13 +123,6 @@ impl<Id, C> ProtocolError<Id> for ChainedProtocolError<Id, C>
 where
     C: ChainedProtocol<Id>,
 {
-    fn description(&self) -> String {
-        match self {
-            Self::Protocol1(err) => format!("Protocol1: {}", err.description()),
-            Self::Protocol2(err) => format!("Protocol2: {}", err.description()),
-        }
-    }
-
     fn required_direct_messages(&self) -> BTreeSet<RoundId> {
         let (protocol_num, round_ids) = match self {
             Self::Protocol1(err) => (1, err.required_direct_messages()),

--- a/manul/src/combinators/misbehave.rs
+++ b/manul/src/combinators/misbehave.rs
@@ -33,7 +33,8 @@ use rand_core::CryptoRngCore;
 
 use crate::protocol::{
     Artifact, BoxedRng, BoxedRound, Deserializer, DirectMessage, EchoBroadcast, EchoRoundParticipation, EntryPoint,
-    FinalizeOutcome, LocalError, NormalBroadcast, ObjectSafeRound, PartyId, Payload, ReceiveError, RoundId, Serializer,
+    FinalizeOutcome, LocalError, NormalBroadcast, ObjectSafeRound, PartyId, Payload, ProtocolMessage, ReceiveError,
+    RoundId, Serializer,
 };
 
 /// A trait describing required properties for a behavior type.
@@ -274,18 +275,9 @@ where
         rng: &mut dyn CryptoRngCore,
         deserializer: &Deserializer,
         from: &Id,
-        echo_broadcast: EchoBroadcast,
-        normal_broadcast: NormalBroadcast,
-        direct_message: DirectMessage,
+        message: ProtocolMessage,
     ) -> Result<Payload, ReceiveError<Id, Self::Protocol>> {
-        self.round.as_ref().receive_message(
-            rng,
-            deserializer,
-            from,
-            echo_broadcast,
-            normal_broadcast,
-            direct_message,
-        )
+        self.round.as_ref().receive_message(rng, deserializer, from, message)
     }
 
     fn finalize(

--- a/manul/src/dev.rs
+++ b/manul/src/dev.rs
@@ -12,6 +12,6 @@ mod run_sync;
 mod session_parameters;
 mod wire_format;
 
-pub use run_sync::run_sync;
+pub use run_sync::{run_sync, ExecutionResult};
 pub use session_parameters::{TestHasher, TestSessionParams, TestSignature, TestSigner, TestVerifier};
 pub use wire_format::{BinaryFormat, HumanReadableFormat};

--- a/manul/src/dev/run_sync.rs
+++ b/manul/src/dev/run_sync.rs
@@ -169,13 +169,19 @@ where
 /// The result of a protocol execution on a set of nodes.
 #[derive(Debug)]
 pub struct ExecutionResult<P: Protocol<SP::Verifier>, SP: SessionParameters> {
+    /// Session reports from each node.
     pub reports: BTreeMap<SP::Verifier, SessionReport<P, SP>>,
 }
+
 impl<P, SP> ExecutionResult<P, SP>
 where
     P: Protocol<SP::Verifier>,
     SP: SessionParameters,
 {
+    /// Attempts to extract the results from each session report.
+    ///
+    /// If any session did finish with a result, returns a string
+    /// with a formatted description of outcomes for each session.
     pub fn results(self) -> Result<BTreeMap<SP::Verifier, P::Result>, String> {
         let mut report_strings = Vec::new();
         let mut results = BTreeMap::new();
@@ -186,7 +192,7 @@ where
                     results.insert(id, result);
                 }
                 _ => {
-                    report_strings.push(format!("Id: {:?}\n{}", id, report.brief()));
+                    report_strings.push(format!("* Id: {:?}\n{}", id, report.brief()));
                 }
             }
         }
@@ -194,7 +200,7 @@ where
         if report_strings.is_empty() {
             Ok(results)
         } else {
-            Err(report_strings.join("\n"))
+            Err(report_strings.join("\n\n"))
         }
     }
 }

--- a/manul/src/protocol.rs
+++ b/manul/src/protocol.rs
@@ -21,7 +21,7 @@ pub use errors::{
     DeserializationError, DirectMessageError, EchoBroadcastError, LocalError, MessageValidationError,
     NormalBroadcastError, ProtocolValidationError, ReceiveError, RemoteError,
 };
-pub use message::{DirectMessage, EchoBroadcast, NormalBroadcast, ProtocolMessagePart};
+pub use message::{DirectMessage, EchoBroadcast, NormalBroadcast, ProtocolMessage, ProtocolMessagePart};
 pub use object_safe::BoxedRound;
 pub use round::{
     Artifact, EchoRoundParticipation, EntryPoint, FinalizeOutcome, NoProtocolErrors, PartyId, Payload, Protocol,

--- a/manul/src/protocol.rs
+++ b/manul/src/protocol.rs
@@ -24,8 +24,8 @@ pub use errors::{
 pub use message::{DirectMessage, EchoBroadcast, NormalBroadcast, ProtocolMessagePart};
 pub use object_safe::BoxedRound;
 pub use round::{
-    Artifact, EchoRoundParticipation, EntryPoint, FinalizeOutcome, PartyId, Payload, Protocol, ProtocolError, Round,
-    RoundId,
+    Artifact, EchoRoundParticipation, EntryPoint, FinalizeOutcome, NoProtocolErrors, PartyId, Payload, Protocol,
+    ProtocolError, Round, RoundId,
 };
 pub use serialization::{Deserializer, Serializer};
 

--- a/manul/src/protocol.rs
+++ b/manul/src/protocol.rs
@@ -25,7 +25,7 @@ pub use message::{DirectMessage, EchoBroadcast, NormalBroadcast, ProtocolMessage
 pub use object_safe::BoxedRound;
 pub use round::{
     Artifact, EchoRoundParticipation, EntryPoint, FinalizeOutcome, NoProtocolErrors, PartyId, Payload, Protocol,
-    ProtocolError, Round, RoundId,
+    ProtocolError, RequiredMessageParts, RequiredMessages, Round, RoundId,
 };
 pub use serialization::{Deserializer, Serializer};
 

--- a/manul/src/protocol/message.rs
+++ b/manul/src/protocol/message.rs
@@ -174,3 +174,14 @@ impl ProtocolMessageWrapper for NormalBroadcast {
 impl ProtocolMessagePart for NormalBroadcast {
     type Error = NormalBroadcastError;
 }
+
+/// A bundle containing the message parts for one round.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProtocolMessage {
+    /// The echo-broadcased message part.
+    pub echo_broadcast: EchoBroadcast,
+    /// The message part broadcasted without additional verification.
+    pub normal_broadcast: NormalBroadcast,
+    /// The message part sent directly to one node.
+    pub direct_message: DirectMessage,
+}

--- a/manul/src/protocol/object_safe.rs
+++ b/manul/src/protocol/object_safe.rs
@@ -9,7 +9,7 @@ use rand_core::{CryptoRng, CryptoRngCore, RngCore};
 
 use super::{
     errors::{LocalError, ReceiveError},
-    message::{DirectMessage, EchoBroadcast, NormalBroadcast},
+    message::{DirectMessage, EchoBroadcast, NormalBroadcast, ProtocolMessage},
     round::{Artifact, EchoRoundParticipation, FinalizeOutcome, PartyId, Payload, Protocol, Round, RoundId},
     serialization::{Deserializer, Serializer},
 };
@@ -81,9 +81,7 @@ pub(crate) trait ObjectSafeRound<Id: PartyId>: 'static + Debug + Send + Sync {
         rng: &mut dyn CryptoRngCore,
         deserializer: &Deserializer,
         from: &Id,
-        echo_broadcast: EchoBroadcast,
-        normal_broadcast: NormalBroadcast,
-        direct_message: DirectMessage,
+        message: ProtocolMessage,
     ) -> Result<Payload, ReceiveError<Id, Self::Protocol>>;
 
     fn finalize(
@@ -187,19 +185,10 @@ where
         rng: &mut dyn CryptoRngCore,
         deserializer: &Deserializer,
         from: &Id,
-        echo_broadcast: EchoBroadcast,
-        normal_broadcast: NormalBroadcast,
-        direct_message: DirectMessage,
+        message: ProtocolMessage,
     ) -> Result<Payload, ReceiveError<Id, Self::Protocol>> {
         let mut boxed_rng = BoxedRng(rng);
-        self.round.receive_message(
-            &mut boxed_rng,
-            deserializer,
-            from,
-            echo_broadcast,
-            normal_broadcast,
-            direct_message,
-        )
+        self.round.receive_message(&mut boxed_rng, deserializer, from, message)
     }
 
     fn finalize(

--- a/manul/src/protocol/round.rs
+++ b/manul/src/protocol/round.rs
@@ -164,7 +164,7 @@ pub trait Protocol<Id>: 'static {
     /// Returns `Ok(())` if the given echo broadcast cannot be deserialized
     /// assuming it is an echo broadcast from the round `round_id`.
     ///
-    /// Normally one would use [`EchoBroadcast::verify_is_not`] when implementing this.
+    /// Normally one would use [`NormalBroadcast::verify_is_not`] when implementing this.
     fn verify_normal_broadcast_is_invalid(
         #[allow(unused_variables)] deserializer: &Deserializer,
         round_id: RoundId,

--- a/manul/src/protocol/round.rs
+++ b/manul/src/protocol/round.rs
@@ -2,7 +2,6 @@ use alloc::{
     boxed::Box,
     collections::{BTreeMap, BTreeSet},
     format,
-    string::String,
 };
 use core::{
     any::Any,
@@ -180,12 +179,7 @@ pub trait Protocol<Id>: 'static {
 ///
 /// Provable here means that we can create an evidence object entirely of messages signed by some party,
 /// which, in combination, prove the party's malicious actions.
-pub trait ProtocolError<Id>: Debug + Clone + Send + Serialize + for<'de> Deserialize<'de> {
-    /// A description of the error that will be included in the generated evidence.
-    ///
-    /// Make it short and informative.
-    fn description(&self) -> String;
-
+pub trait ProtocolError<Id>: Display + Debug + Clone + Send + Serialize + for<'de> Deserialize<'de> {
     /// The rounds direct messages from which are required to prove malicious behavior for this error.
     ///
     /// **Note:** Should not include the round where the error happened.
@@ -245,13 +239,11 @@ pub trait ProtocolError<Id>: Debug + Clone + Send + Serialize + for<'de> Deseria
     ) -> Result<(), ProtocolValidationError>;
 }
 
-// A convenience implementation for protocols that don't define any errors.
-// Have to do it for `()`, since `!` is unstable.
-impl<Id> ProtocolError<Id> for () {
-    fn description(&self) -> String {
-        panic!("Attempt to use an empty error type in an evidence. This is a bug in the protocol implementation.")
-    }
+#[derive(displaydoc::Display, Debug, Clone, Copy, Serialize, Deserialize)]
+/// A stub type indicating that this protocol does not generate any provable errors.
+pub struct NoProtocolErrors;
 
+impl<Id> ProtocolError<Id> for NoProtocolErrors {
     fn verify_messages_constitute_error(
         &self,
         _deserializer: &Deserializer,

--- a/manul/src/protocol/round.rs
+++ b/manul/src/protocol/round.rs
@@ -180,6 +180,10 @@ pub trait Protocol<Id>: 'static {
 /// Provable here means that we can create an evidence object entirely of messages signed by some party,
 /// which, in combination, prove the party's malicious actions.
 pub trait ProtocolError<Id>: Display + Debug + Clone + Send + Serialize + for<'de> Deserialize<'de> {
+    /// Additional data that cannot be derived from the node's messages alone
+    /// and therefore has to be supplied externally during evidence verification.
+    type AssociatedData: Debug;
+
     /// The rounds direct messages from which are required to prove malicious behavior for this error.
     ///
     /// **Note:** Should not include the round where the error happened.
@@ -229,6 +233,7 @@ pub trait ProtocolError<Id>: Display + Debug + Clone + Send + Serialize + for<'d
         deserializer: &Deserializer,
         guilty_party: &Id,
         shared_randomness: &[u8],
+        associated_data: &Self::AssociatedData,
         echo_broadcast: EchoBroadcast,
         normal_broadcast: NormalBroadcast,
         direct_message: DirectMessage,
@@ -244,11 +249,14 @@ pub trait ProtocolError<Id>: Display + Debug + Clone + Send + Serialize + for<'d
 pub struct NoProtocolErrors;
 
 impl<Id> ProtocolError<Id> for NoProtocolErrors {
+    type AssociatedData = ();
+
     fn verify_messages_constitute_error(
         &self,
         _deserializer: &Deserializer,
         _guilty_party: &Id,
         _shared_randomness: &[u8],
+        _associated_data: &Self::AssociatedData,
         _echo_broadcast: EchoBroadcast,
         _normal_broadcast: NormalBroadcast,
         _direct_message: DirectMessage,

--- a/manul/src/session/echo.rs
+++ b/manul/src/session/echo.rs
@@ -18,7 +18,8 @@ use super::{
 use crate::{
     protocol::{
         Artifact, BoxedRound, Deserializer, DirectMessage, EchoBroadcast, FinalizeOutcome, MessageValidationError,
-        NormalBroadcast, Payload, Protocol, ProtocolMessagePart, ReceiveError, Round, RoundId, Serializer,
+        NormalBroadcast, Payload, Protocol, ProtocolMessage, ProtocolMessagePart, ReceiveError, Round, RoundId,
+        Serializer,
     },
     utils::SerializableMap,
 };
@@ -180,16 +181,16 @@ where
         _rng: &mut impl CryptoRngCore,
         deserializer: &Deserializer,
         from: &SP::Verifier,
-        echo_broadcast: EchoBroadcast,
-        normal_broadcast: NormalBroadcast,
-        direct_message: DirectMessage,
+        message: ProtocolMessage,
     ) -> Result<Payload, ReceiveError<SP::Verifier, Self::Protocol>> {
         debug!("{:?}: received an echo message from {:?}", self.verifier, from);
 
-        echo_broadcast.assert_is_none()?;
-        direct_message.assert_is_none()?;
+        message.echo_broadcast.assert_is_none()?;
+        message.direct_message.assert_is_none()?;
 
-        let message = normal_broadcast.deserialize::<EchoRoundMessage<SP>>(deserializer)?;
+        let message = message
+            .normal_broadcast
+            .deserialize::<EchoRoundMessage<SP>>(deserializer)?;
 
         // Check that the received message contains entries from `expected_echos`.
         // It is an unprovable fault.

--- a/manul/src/session/evidence.rs
+++ b/manul/src/session/evidence.rs
@@ -134,7 +134,7 @@ where
             })
             .collect::<Result<BTreeMap<_, _>, _>>()?;
 
-        let description = format!("Protocol error: {}", error.description());
+        let description = format!("Protocol error: {error}");
 
         Ok(Self {
             guilty_party: verifier.clone(),

--- a/manul/src/session/evidence.rs
+++ b/manul/src/session/evidence.rs
@@ -50,7 +50,7 @@ impl From<MessageVerificationError> for EvidenceError {
 
 impl From<NormalBroadcastError> for EvidenceError {
     fn from(error: NormalBroadcastError) -> Self {
-        Self::InvalidEvidence(format!("Failed to deserialize normal brroadcast: {:?}", error))
+        Self::InvalidEvidence(format!("Failed to deserialize normal broadcast: {:?}", error))
     }
 }
 

--- a/manul/src/session/evidence.rs
+++ b/manul/src/session/evidence.rs
@@ -94,45 +94,50 @@ where
         error: P::ProtocolError,
         transcript: &Transcript<P, SP>,
     ) -> Result<Self, LocalError> {
-        let echo_broadcasts = error
-            .required_echo_broadcasts()
-            .iter()
-            .map(|round_id| {
-                transcript
-                    .get_echo_broadcast(round_id.clone(), verifier)
-                    .map(|echo| (round_id.clone(), echo))
-            })
-            .collect::<Result<BTreeMap<_, _>, _>>()?;
+        let required_messages = error.required_messages();
 
-        let normal_broadcasts = error
-            .required_normal_broadcasts()
-            .iter()
-            .map(|round_id| {
-                transcript
-                    .get_normal_broadcast(round_id.clone(), verifier)
-                    .map(|bc| (round_id.clone(), bc))
-            })
-            .collect::<Result<BTreeMap<_, _>, _>>()?;
+        let echo_broadcast = if required_messages.this_round.echo_broadcast {
+            Some(echo_broadcast)
+        } else {
+            None
+        };
+        let normal_broadcast = if required_messages.this_round.normal_broadcast {
+            Some(normal_broadcast)
+        } else {
+            None
+        };
+        let direct_message = if required_messages.this_round.direct_message {
+            Some(direct_message)
+        } else {
+            None
+        };
 
-        let direct_messages = error
-            .required_direct_messages()
-            .iter()
-            .map(|round_id| {
-                transcript
-                    .get_direct_message(round_id.clone(), verifier)
-                    .map(|dm| (round_id.clone(), dm))
-            })
-            .collect::<Result<BTreeMap<_, _>, _>>()?;
+        let mut echo_broadcasts = BTreeMap::new();
+        let mut normal_broadcasts = BTreeMap::new();
+        let mut direct_messages = BTreeMap::new();
+        if let Some(previous_rounds) = required_messages.previous_rounds {
+            for (round_id, required) in previous_rounds {
+                if required.echo_broadcast {
+                    echo_broadcasts.insert(round_id.clone(), transcript.get_echo_broadcast(&round_id, verifier)?);
+                }
+                if required.normal_broadcast {
+                    normal_broadcasts.insert(round_id.clone(), transcript.get_normal_broadcast(&round_id, verifier)?);
+                }
+                if required.direct_message {
+                    direct_messages.insert(round_id.clone(), transcript.get_direct_message(&round_id, verifier)?);
+                }
+            }
+        }
 
-        let combined_echos = error
-            .required_combined_echos()
-            .iter()
-            .map(|round_id| {
-                transcript
-                    .get_normal_broadcast(round_id.echo(), verifier)
-                    .map(|dm| (round_id.clone(), dm))
-            })
-            .collect::<Result<BTreeMap<_, _>, _>>()?;
+        let mut combined_echos = BTreeMap::new();
+        if let Some(required_combined_echos) = required_messages.combined_echos {
+            for round_id in required_combined_echos {
+                combined_echos.insert(
+                    round_id.clone(),
+                    transcript.get_normal_broadcast(&round_id.echo(), verifier)?,
+                );
+            }
+        }
 
         let description = format!("Protocol error: {error}");
 
@@ -424,9 +429,9 @@ impl InvalidNormalBroadcastEvidence {
 #[derive(Clone, Serialize, Deserialize)]
 struct ProtocolEvidence<Id, P: Protocol<Id>> {
     error: P::ProtocolError,
-    direct_message: SignedMessagePart<DirectMessage>,
-    echo_broadcast: SignedMessagePart<EchoBroadcast>,
-    normal_broadcast: SignedMessagePart<NormalBroadcast>,
+    direct_message: Option<SignedMessagePart<DirectMessage>>,
+    echo_broadcast: Option<SignedMessagePart<EchoBroadcast>>,
+    normal_broadcast: Option<SignedMessagePart<NormalBroadcast>>,
     direct_messages: SerializableMap<RoundId, SignedMessagePart<DirectMessage>>,
     echo_broadcasts: SerializableMap<RoundId, SignedMessagePart<EchoBroadcast>>,
     normal_broadcasts: SerializableMap<RoundId, SignedMessagePart<NormalBroadcast>>,
@@ -446,7 +451,7 @@ where
     for (round_id, message_part) in message_parts.iter() {
         let verified = message_part.clone().verify::<SP>(verifier)?;
         let metadata = verified.metadata();
-        if metadata.session_id() != expected_session_id || &metadata.round_id() != round_id {
+        if metadata.session_id() != expected_session_id || metadata.round_id() != round_id {
             return Err(EvidenceError::InvalidEvidence(
                 "Invalid attached message metadata".into(),
             ));
@@ -454,6 +459,31 @@ where
         verified_parts.insert(round_id.clone(), verified.into_payload());
     }
     Ok(verified_parts)
+}
+
+fn verify_message_part<SP, T>(
+    verifier: &SP::Verifier,
+    expected_session_id: &SessionId,
+    expected_round_id: &RoundId,
+    message_part: &Option<SignedMessagePart<T>>,
+) -> Result<T, EvidenceError>
+where
+    SP: SessionParameters,
+    T: Clone + ProtocolMessagePart,
+{
+    let verified_part = if let Some(message_part) = message_part {
+        let metadata = message_part.metadata();
+        if metadata.session_id() != expected_session_id || metadata.round_id() != expected_round_id {
+            return Err(EvidenceError::InvalidEvidence(
+                "Invalid attached message metadata".into(),
+            ));
+        }
+        message_part.clone().verify::<SP>(verifier)?.into_payload()
+    } else {
+        T::none()
+    };
+
+    Ok(verified_part)
 }
 
 impl<Id, P> ProtocolEvidence<Id, P>
@@ -470,28 +500,27 @@ where
     where
         SP: SessionParameters<Verifier = Id>,
     {
-        let session_id = self.direct_message.metadata().session_id();
-        let round_id = self.direct_message.metadata().round_id();
+        // Find the message part from the message that triggered the error
+        // and use it as a source of RoundID and SessionID.
+        // At least one part of that message will be required, as enforced by `RequiredMessageParts` invariant.
+        let metadata = if let Some(message) = &self.direct_message {
+            message.metadata()
+        } else if let Some(message) = &self.echo_broadcast {
+            message.metadata()
+        } else if let Some(message) = &self.normal_broadcast {
+            message.metadata()
+        } else {
+            return Err(EvidenceError::Local(LocalError::new(
+                "At least one part of the trigger message must be present",
+            )));
+        };
 
-        let direct_message = self.direct_message.clone().verify::<SP>(verifier)?.into_payload();
+        let session_id = metadata.session_id();
+        let round_id = metadata.round_id();
 
-        let echo_broadcast = self.echo_broadcast.clone().verify::<SP>(verifier)?.into_payload();
-        if self.echo_broadcast.metadata().session_id() != session_id
-            || self.echo_broadcast.metadata().round_id() != round_id
-        {
-            return Err(EvidenceError::InvalidEvidence(
-                "Invalid attached message metadata".into(),
-            ));
-        }
-
-        let normal_broadcast = self.normal_broadcast.clone().verify::<SP>(verifier)?.into_payload();
-        if self.normal_broadcast.metadata().session_id() != session_id
-            || self.normal_broadcast.metadata().round_id() != round_id
-        {
-            return Err(EvidenceError::InvalidEvidence(
-                "Invalid attached message metadata".into(),
-            ));
-        }
+        let direct_message = verify_message_part::<SP, _>(verifier, session_id, round_id, &self.direct_message)?;
+        let echo_broadcast = verify_message_part::<SP, _>(verifier, session_id, round_id, &self.echo_broadcast)?;
+        let normal_broadcast = verify_message_part::<SP, _>(verifier, session_id, round_id, &self.normal_broadcast)?;
 
         let mut direct_messages = verify_message_parts::<SP, _>(verifier, session_id, &self.direct_messages)?;
         let mut echo_broadcasts = verify_message_parts::<SP, _>(verifier, session_id, &self.echo_broadcasts)?;
@@ -514,7 +543,7 @@ where
             for (other_verifier, echo_broadcast) in echo_set.echo_broadcasts.iter() {
                 let verified_echo_broadcast = echo_broadcast.clone().verify::<SP>(other_verifier)?;
                 let metadata = verified_echo_broadcast.metadata();
-                if metadata.session_id() != session_id || &metadata.round_id() != round_id {
+                if metadata.session_id() != session_id || metadata.round_id() != round_id {
                     return Err(EvidenceError::InvalidEvidence(
                         "Invalid attached message metadata".into(),
                     ));

--- a/manul/src/session/message.rs
+++ b/manul/src/session/message.rs
@@ -56,10 +56,10 @@ pub(crate) struct MessageMetadata {
 }
 
 impl MessageMetadata {
-    pub fn new(session_id: &SessionId, round_id: RoundId) -> Self {
+    pub fn new(session_id: &SessionId, round_id: &RoundId) -> Self {
         Self {
             session_id: session_id.clone(),
-            round_id,
+            round_id: round_id.clone(),
         }
     }
 
@@ -67,8 +67,8 @@ impl MessageMetadata {
         &self.session_id
     }
 
-    pub fn round_id(&self) -> RoundId {
-        self.round_id.clone()
+    pub fn round_id(&self) -> &RoundId {
+        &self.round_id
     }
 }
 
@@ -103,7 +103,7 @@ where
         rng: &mut impl CryptoRngCore,
         signer: &SP::Signer,
         session_id: &SessionId,
-        round_id: RoundId,
+        round_id: &RoundId,
         message: M,
     ) -> Result<Self, LocalError>
     where
@@ -197,7 +197,7 @@ where
         rng: &mut impl CryptoRngCore,
         signer: &SP::Signer,
         session_id: &SessionId,
-        round_id: RoundId,
+        round_id: &RoundId,
         destination: &Verifier,
         direct_message: DirectMessage,
         echo_broadcast: SignedMessagePart<EchoBroadcast>,

--- a/manul/src/session/session.rs
+++ b/manul/src/session/session.rs
@@ -841,10 +841,13 @@ fn filter_messages<Verifier>(
 mod tests {
     use impls::impls;
 
-    use super::{Message, ProcessedArtifact, ProcessedMessage, Session, SessionParameters, VerifiedMessage};
+    use super::{
+        Deserializer, Message, ProcessedArtifact, ProcessedMessage, RoundId, Session, SessionParameters,
+        VerifiedMessage,
+    };
     use crate::{
         dev::{BinaryFormat, TestSessionParams, TestVerifier},
-        protocol::{NoProtocolErrors, Protocol},
+        protocol::{DirectMessage, EchoBroadcast, MessageValidationError, NoProtocolErrors, NormalBroadcast, Protocol},
     };
 
     #[test]
@@ -864,6 +867,30 @@ mod tests {
         impl Protocol<<SP as SessionParameters>::Verifier> for DummyProtocol {
             type Result = ();
             type ProtocolError = NoProtocolErrors;
+
+            fn verify_direct_message_is_invalid(
+                _deserializer: &Deserializer,
+                _round_id: &RoundId,
+                _message: &DirectMessage,
+            ) -> Result<(), MessageValidationError> {
+                unimplemented!()
+            }
+
+            fn verify_echo_broadcast_is_invalid(
+                _deserializer: &Deserializer,
+                _round_id: &RoundId,
+                _message: &EchoBroadcast,
+            ) -> Result<(), MessageValidationError> {
+                unimplemented!()
+            }
+
+            fn verify_normal_broadcast_is_invalid(
+                _deserializer: &Deserializer,
+                _round_id: &RoundId,
+                _message: &NormalBroadcast,
+            ) -> Result<(), MessageValidationError> {
+                unimplemented!()
+            }
         }
 
         // We need `Session` to be `Send` so that we send a `Session` object to a task

--- a/manul/src/session/session.rs
+++ b/manul/src/session/session.rs
@@ -843,7 +843,7 @@ mod tests {
     use super::{Message, ProcessedArtifact, ProcessedMessage, Session, SessionParameters, VerifiedMessage};
     use crate::{
         dev::{BinaryFormat, TestSessionParams, TestVerifier},
-        protocol::Protocol,
+        protocol::{NoProtocolErrors, Protocol},
     };
 
     #[test]
@@ -862,7 +862,7 @@ mod tests {
 
         impl Protocol<<SP as SessionParameters>::Verifier> for DummyProtocol {
             type Result = ();
-            type ProtocolError = ();
+            type ProtocolError = NoProtocolErrors;
         }
 
         // We need `Session` to be `Send` so that we send a `Session` object to a task

--- a/manul/src/session/transcript.rs
+++ b/manul/src/session/transcript.rs
@@ -116,11 +116,11 @@ where
 
     pub fn get_echo_broadcast(
         &self,
-        round_id: RoundId,
+        round_id: &RoundId,
         from: &SP::Verifier,
     ) -> Result<SignedMessagePart<EchoBroadcast>, LocalError> {
         self.echo_broadcasts
-            .get(&round_id)
+            .get(round_id)
             .ok_or_else(|| LocalError::new(format!("No echo broadcasts registered for {round_id:?}")))?
             .get(from)
             .cloned()
@@ -129,11 +129,11 @@ where
 
     pub fn get_normal_broadcast(
         &self,
-        round_id: RoundId,
+        round_id: &RoundId,
         from: &SP::Verifier,
     ) -> Result<SignedMessagePart<NormalBroadcast>, LocalError> {
         self.normal_broadcasts
-            .get(&round_id)
+            .get(round_id)
             .ok_or_else(|| LocalError::new(format!("No normal broadcasts registered for {round_id:?}")))?
             .get(from)
             .cloned()
@@ -142,11 +142,11 @@ where
 
     pub fn get_direct_message(
         &self,
-        round_id: RoundId,
+        round_id: &RoundId,
         from: &SP::Verifier,
     ) -> Result<SignedMessagePart<DirectMessage>, LocalError> {
         self.direct_messages
-            .get(&round_id)
+            .get(round_id)
             .ok_or_else(|| LocalError::new(format!("No direct messages registered for {round_id:?}")))?
             .get(from)
             .cloned()
@@ -159,10 +159,10 @@ where
 
     pub fn echo_broadcasts(
         &self,
-        round_id: RoundId,
+        round_id: &RoundId,
     ) -> Result<BTreeMap<SP::Verifier, SignedMessagePart<EchoBroadcast>>, LocalError> {
         self.echo_broadcasts
-            .get(&round_id)
+            .get(round_id)
             .cloned()
             .ok_or_else(|| LocalError::new(format!("Echo-broadcasts for {round_id:?} are not in the transcript")))
     }

--- a/manul/src/tests/partial_echo.rs
+++ b/manul/src/tests/partial_echo.rs
@@ -11,9 +11,9 @@ use serde::{Deserialize, Serialize};
 use crate::{
     dev::{run_sync, BinaryFormat, TestSessionParams, TestSigner, TestVerifier},
     protocol::{
-        Artifact, BoxedRound, Deserializer, DirectMessage, EchoBroadcast, EchoRoundParticipation, EntryPoint,
-        FinalizeOutcome, LocalError, NoProtocolErrors, NormalBroadcast, PartyId, Payload, Protocol,
-        ProtocolMessagePart, ReceiveError, Round, RoundId, Serializer,
+        Artifact, BoxedRound, Deserializer, EchoBroadcast, EchoRoundParticipation, EntryPoint, FinalizeOutcome,
+        LocalError, NoProtocolErrors, PartyId, Payload, Protocol, ProtocolMessage, ProtocolMessagePart, ReceiveError,
+        Round, RoundId, Serializer,
     },
     signature::Keypair,
 };
@@ -101,17 +101,15 @@ impl<Id: PartyId + Serialize + for<'de> Deserialize<'de>> Round<Id> for Round1<I
         _rng: &mut impl CryptoRngCore,
         deserializer: &Deserializer,
         from: &Id,
-        echo_broadcast: EchoBroadcast,
-        normal_broadcast: NormalBroadcast,
-        direct_message: DirectMessage,
+        message: ProtocolMessage,
     ) -> Result<Payload, ReceiveError<Id, Self::Protocol>> {
-        normal_broadcast.assert_is_none()?;
-        direct_message.assert_is_none()?;
+        message.normal_broadcast.assert_is_none()?;
+        message.direct_message.assert_is_none()?;
 
         if self.inputs.expecting_messages_from.is_empty() {
-            echo_broadcast.assert_is_none()?;
+            message.echo_broadcast.assert_is_none()?;
         } else {
-            let echo = echo_broadcast.deserialize::<Round1Echo<Id>>(deserializer)?;
+            let echo = message.echo_broadcast.deserialize::<Round1Echo<Id>>(deserializer)?;
             assert_eq!(&echo.sender, from);
             assert!(self.inputs.expecting_messages_from.contains(from));
         }

--- a/manul/src/tests/partial_echo.rs
+++ b/manul/src/tests/partial_echo.rs
@@ -11,9 +11,9 @@ use serde::{Deserialize, Serialize};
 use crate::{
     dev::{run_sync, BinaryFormat, TestSessionParams, TestSigner, TestVerifier},
     protocol::{
-        Artifact, BoxedRound, Deserializer, EchoBroadcast, EchoRoundParticipation, EntryPoint, FinalizeOutcome,
-        LocalError, NoProtocolErrors, PartyId, Payload, Protocol, ProtocolMessage, ProtocolMessagePart, ReceiveError,
-        Round, RoundId, Serializer,
+        Artifact, BoxedRound, Deserializer, DirectMessage, EchoBroadcast, EchoRoundParticipation, EntryPoint,
+        FinalizeOutcome, LocalError, MessageValidationError, NoProtocolErrors, NormalBroadcast, PartyId, Payload,
+        Protocol, ProtocolMessage, ProtocolMessagePart, ReceiveError, Round, RoundId, Serializer,
     },
     signature::Keypair,
 };
@@ -24,6 +24,30 @@ struct PartialEchoProtocol<Id>(PhantomData<Id>);
 impl<Id: PartyId> Protocol<Id> for PartialEchoProtocol<Id> {
     type Result = ();
     type ProtocolError = NoProtocolErrors;
+
+    fn verify_direct_message_is_invalid(
+        _deserializer: &Deserializer,
+        _round_id: &RoundId,
+        _message: &DirectMessage,
+    ) -> Result<(), MessageValidationError> {
+        unimplemented!()
+    }
+
+    fn verify_echo_broadcast_is_invalid(
+        _deserializer: &Deserializer,
+        _round_id: &RoundId,
+        _message: &EchoBroadcast,
+    ) -> Result<(), MessageValidationError> {
+        unimplemented!()
+    }
+
+    fn verify_normal_broadcast_is_invalid(
+        _deserializer: &Deserializer,
+        _round_id: &RoundId,
+        _message: &NormalBroadcast,
+    ) -> Result<(), MessageValidationError> {
+        unimplemented!()
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/manul/src/tests/partial_echo.rs
+++ b/manul/src/tests/partial_echo.rs
@@ -1,7 +1,5 @@
 use alloc::{
     collections::{BTreeMap, BTreeSet},
-    format,
-    string::String,
     vec,
     vec::Vec,
 };
@@ -14,8 +12,8 @@ use crate::{
     dev::{run_sync, BinaryFormat, TestSessionParams, TestSigner, TestVerifier},
     protocol::{
         Artifact, BoxedRound, Deserializer, DirectMessage, EchoBroadcast, EchoRoundParticipation, EntryPoint,
-        FinalizeOutcome, LocalError, NormalBroadcast, PartyId, Payload, Protocol, ProtocolError, ProtocolMessagePart,
-        ProtocolValidationError, ReceiveError, Round, RoundId, Serializer,
+        FinalizeOutcome, LocalError, NoProtocolErrors, NormalBroadcast, PartyId, Payload, Protocol,
+        ProtocolMessagePart, ReceiveError, Round, RoundId, Serializer,
     },
     signature::Keypair,
 };
@@ -25,32 +23,7 @@ struct PartialEchoProtocol<Id>(PhantomData<Id>);
 
 impl<Id: PartyId> Protocol<Id> for PartialEchoProtocol<Id> {
     type Result = ();
-    type ProtocolError = PartialEchoProtocolError<Id>;
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-struct PartialEchoProtocolError<Id>(PhantomData<Id>);
-
-impl<Id: PartyId> ProtocolError<Id> for PartialEchoProtocolError<Id> {
-    fn description(&self) -> String {
-        format!("{:?}", self)
-    }
-
-    fn verify_messages_constitute_error(
-        &self,
-        _deserializer: &Deserializer,
-        _guilty_party: &Id,
-        _shared_randomness: &[u8],
-        _echo_broadcast: EchoBroadcast,
-        _normal_broadcast: NormalBroadcast,
-        _direct_message: DirectMessage,
-        _echo_broadcasts: BTreeMap<RoundId, EchoBroadcast>,
-        _normal_broadcasts: BTreeMap<RoundId, NormalBroadcast>,
-        _direct_messages: BTreeMap<RoundId, DirectMessage>,
-        _combined_echos: BTreeMap<RoundId, BTreeMap<Id, EchoBroadcast>>,
-    ) -> Result<(), ProtocolValidationError> {
-        unimplemented!()
-    }
+    type ProtocolError = NoProtocolErrors;
 }
 
 #[derive(Debug, Clone)]


### PR DESCRIPTION
Various things coming up in the process of working on https://github.com/entropyxyz/synedrion/pull/170:
- Expose `ExecutionResult` in `dev`
- Use `Display` impl to generate descriptions for protocol errors instead of a separate method
- Add a `NoProtocolErrors` stub type to use for protocols that don't generate provable errors (instead of the previous `()` which for whatever reason does not impl `Display`)
- Add associated data support that's needed for KeyRefresh (and probably for signing too). Fixes #10
- Bundle message parts into `ProtocolMessage`. Fixes #48
- Merge `ProtocolError::required_*` methods into one `required_messages()`. This makes it easier to write in complicated cases, since all requirements are bundled together. Also the user can now declare which parts of the main message they want to keep, instead of saving everything, which is generally not needed.
- Made `Protocol::verify_*_is_invalid()` mandatory to implement. There is no good default implementation for them that doesn't lead to runtime errors.