### PR TITLE
Remove the RNG argument from `Round::receive_message()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `RoundId`s are passed by reference in public methods since they are not `Copy`. ([#79])
 - Using a single `ProtocolError::required_messages()` instead of multiple methods. ([#79])
 - `Protocol::verify_*_is_invalid()` are now mandatory to implement. ([#79])
+- Removed the RNG parameter from `Round::receive_message()` and `Session::process_message()`. ([#83])
 
 
 ### Added
@@ -35,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#76]: https://github.com/entropyxyz/manul/pull/76
 [#77]: https://github.com/entropyxyz/manul/pull/77
 [#79]: https://github.com/entropyxyz/manul/pull/79
+[#83]: https://github.com/entropyxyz/manul/pull/83
 
 
 ## [0.1.0] - 2024-11-19

--- a/examples/src/simple.rs
+++ b/examples/src/simple.rs
@@ -251,7 +251,6 @@ impl<Id: PartyId> Round<Id> for Round1<Id> {
 
     fn receive_message(
         &self,
-        _rng: &mut impl CryptoRngCore,
         deserializer: &Deserializer,
         from: &Id,
         message: ProtocolMessage,
@@ -351,7 +350,6 @@ impl<Id: PartyId> Round<Id> for Round2<Id> {
 
     fn receive_message(
         &self,
-        _rng: &mut impl CryptoRngCore,
         deserializer: &Deserializer,
         from: &Id,
         message: ProtocolMessage,

--- a/examples/tests/async_runner.rs
+++ b/examples/tests/async_runner.rs
@@ -94,7 +94,7 @@ where
         for preprocessed in cached_messages {
             // In production usage, this would happen in a spawned task and relayed back to the main task.
             debug!("{key:?}: Applying a cached message");
-            let processed = session.process_message(rng, preprocessed);
+            let processed = session.process_message(preprocessed);
 
             // This would happen in a host task.
             session.add_processed_message(&mut accum, processed)?;
@@ -124,7 +124,7 @@ where
                 Some(preprocessed) => {
                     // In production usage, this would happen in a separate task.
                     debug!("{key:?}: Applying a message from {:?}", incoming.from);
-                    let processed = session.process_message(rng, preprocessed);
+                    let processed = session.process_message(preprocessed);
                     // In production usage, this would be a host task.
                     session.add_processed_message(&mut accum, processed)?;
                 }

--- a/manul/benches/empty_rounds.rs
+++ b/manul/benches/empty_rounds.rs
@@ -134,7 +134,6 @@ impl<Id: PartyId> Round<Id> for EmptyRound<Id> {
 
     fn receive_message(
         &self,
-        _rng: &mut impl CryptoRngCore,
         deserializer: &Deserializer,
         _from: &Id,
         message: ProtocolMessage,

--- a/manul/src/combinators/chain.rs
+++ b/manul/src/combinators/chain.rs
@@ -458,19 +458,16 @@ where
 
     fn receive_message(
         &self,
-        rng: &mut dyn CryptoRngCore,
         deserializer: &Deserializer,
         from: &Id,
         message: ProtocolMessage,
     ) -> Result<Payload, ReceiveError<Id, Self::Protocol>> {
         match &self.state {
-            ChainState::Protocol1 { round, .. } => {
-                match round.as_ref().receive_message(rng, deserializer, from, message) {
-                    Ok(payload) => Ok(payload),
-                    Err(err) => Err(err.map(ChainedProtocolError::from_protocol1)),
-                }
-            }
-            ChainState::Protocol2(round) => match round.as_ref().receive_message(rng, deserializer, from, message) {
+            ChainState::Protocol1 { round, .. } => match round.as_ref().receive_message(deserializer, from, message) {
+                Ok(payload) => Ok(payload),
+                Err(err) => Err(err.map(ChainedProtocolError::from_protocol1)),
+            },
+            ChainState::Protocol2(round) => match round.as_ref().receive_message(deserializer, from, message) {
                 Ok(payload) => Ok(payload),
                 Err(err) => Err(err.map(ChainedProtocolError::from_protocol2)),
             },

--- a/manul/src/combinators/misbehave.rs
+++ b/manul/src/combinators/misbehave.rs
@@ -272,12 +272,11 @@ where
 
     fn receive_message(
         &self,
-        rng: &mut dyn CryptoRngCore,
         deserializer: &Deserializer,
         from: &Id,
         message: ProtocolMessage,
     ) -> Result<Payload, ReceiveError<Id, Self::Protocol>> {
-        self.round.as_ref().receive_message(rng, deserializer, from, message)
+        self.round.as_ref().receive_message(deserializer, from, message)
     }
 
     fn finalize(

--- a/manul/src/dev/run_sync.rs
+++ b/manul/src/dev/run_sync.rs
@@ -61,7 +61,7 @@ where
                                 message.from(),
                                 session.verifier()
                             );
-                            let processed = session.process_message(rng, message);
+                            let processed = session.process_message(message);
                             session.add_processed_message(&mut accum, processed)?;
                         }
                     }
@@ -137,7 +137,7 @@ where
             let preprocessed = session.preprocess_message(&mut accum, &message.from, message.message)?;
 
             if let Some(verified) = preprocessed.ok() {
-                let processed = session.process_message(rng, verified);
+                let processed = session.process_message(verified);
                 session.add_processed_message(&mut accum, processed)?;
             }
 

--- a/manul/src/protocol/object_safe.rs
+++ b/manul/src/protocol/object_safe.rs
@@ -78,7 +78,6 @@ pub(crate) trait ObjectSafeRound<Id: PartyId>: 'static + Debug + Send + Sync {
 
     fn receive_message(
         &self,
-        rng: &mut dyn CryptoRngCore,
         deserializer: &Deserializer,
         from: &Id,
         message: ProtocolMessage,
@@ -182,13 +181,11 @@ where
 
     fn receive_message(
         &self,
-        rng: &mut dyn CryptoRngCore,
         deserializer: &Deserializer,
         from: &Id,
         message: ProtocolMessage,
     ) -> Result<Payload, ReceiveError<Id, Self::Protocol>> {
-        let mut boxed_rng = BoxedRng(rng);
-        self.round.receive_message(&mut boxed_rng, deserializer, from, message)
+        self.round.receive_message(deserializer, from, message)
     }
 
     fn finalize(

--- a/manul/src/protocol/round.rs
+++ b/manul/src/protocol/round.rs
@@ -533,7 +533,6 @@ pub trait Round<Id: PartyId>: 'static + Debug + Send + Sync {
     /// it has already been done by the execution layer.
     fn receive_message(
         &self,
-        rng: &mut impl CryptoRngCore,
         deserializer: &Deserializer,
         from: &Id,
         message: ProtocolMessage,

--- a/manul/src/session/echo.rs
+++ b/manul/src/session/echo.rs
@@ -178,7 +178,6 @@ where
 
     fn receive_message(
         &self,
-        _rng: &mut impl CryptoRngCore,
         deserializer: &Deserializer,
         from: &SP::Verifier,
         message: ProtocolMessage,

--- a/manul/src/session/session.rs
+++ b/manul/src/session/session.rs
@@ -401,11 +401,7 @@ where
     /// Processes a verified message.
     ///
     /// This can be called in a spawned task if it is known to take a long time.
-    pub fn process_message(
-        &self,
-        rng: &mut impl CryptoRngCore,
-        message: VerifiedMessage<SP::Verifier>,
-    ) -> ProcessedMessage<P, SP> {
+    pub fn process_message(&self, message: VerifiedMessage<SP::Verifier>) -> ProcessedMessage<P, SP> {
         let protocol_message = ProtocolMessage {
             echo_broadcast: message.echo_broadcast().clone(),
             normal_broadcast: message.normal_broadcast().clone(),
@@ -414,7 +410,7 @@ where
         let processed = self
             .round
             .as_ref()
-            .receive_message(rng, &self.deserializer, message.from(), protocol_message);
+            .receive_message(&self.deserializer, message.from(), protocol_message);
         // We could filter out and return a possible `LocalError` at this stage,
         // but it's no harm in delaying it until `ProcessedMessage` is added to the accumulator.
         ProcessedMessage { message, processed }

--- a/manul/src/tests/partial_echo.rs
+++ b/manul/src/tests/partial_echo.rs
@@ -122,7 +122,6 @@ impl<Id: PartyId + Serialize + for<'de> Deserialize<'de>> Round<Id> for Round1<I
 
     fn receive_message(
         &self,
-        _rng: &mut impl CryptoRngCore,
         deserializer: &Deserializer,
         from: &Id,
         message: ProtocolMessage,


### PR DESCRIPTION
Originally it was added to support a single ZK proof in `synedrion` where the verification required an RNG. The reason it did was to only pass it to [`crypto_primes::is_prime_with_rng()`](https://docs.rs/crypto-primes/latest/crypto_primes/fn.is_prime_with_rng.html). After some consideration, I think it was not a correct way to handle that.

Since we want to be able to generate verifiable evidence for every `receive_message()` error, the outcome of `receive_message()` cannot be random (or we would have to store the RNG state which we don't have access to). If some of its internals need an RNG, it should construct one using `shared_randomness`, `AssociatedData`, or whatever else would be available during evidence verification, as a seed. 

Specifically for primality checking, it seems that there is no need for an RNG at all (see https://github.com/entropyxyz/crypto-primes/issues/21), although this method is too new and is not included in FIPS recommendations.  