### PR TITLE
`RoundId` changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Using a single `ProtocolError::required_messages()` instead of multiple methods. ([#79])
 - `Protocol::verify_*_is_invalid()` are now mandatory to implement. ([#79])
 - Removed the RNG parameter from `Round::receive_message()` and `Session::process_message()`. ([#83])
+- Renamed `Round::entry_round()` to `entry_round_id()` and made it mandatory to implement. ([#84])
 
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `impl From<NormalBroadcastError> for ProtocolValidationError` (to match what already exists for other messages). ([#77])
 - Exposed `dev::ExecutionResult`. ([#79])
 - `NoProtocolErrors` stub type to indicate that the protocol does not generate any provable errors. ([#79])
+- Conversion from `u8` to `RoundId` and comparison of `RoundId` with `u8`. ([#84])
 
 
 [#75]: https://github.com/entropyxyz/manul/pull/75
@@ -37,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#77]: https://github.com/entropyxyz/manul/pull/77
 [#79]: https://github.com/entropyxyz/manul/pull/79
 [#83]: https://github.com/entropyxyz/manul/pull/83
+[#84]: https://github.com/entropyxyz/manul/pull/84
 
 
 ## [0.1.0] - 2024-11-19

--- a/examples/src/simple.rs
+++ b/examples/src/simple.rs
@@ -33,8 +33,8 @@ impl<Id> ProtocolError<Id> for SimpleProtocolError {
             }
             Self::Round2InvalidPosition => RequiredMessages::new(
                 RequiredMessageParts::direct_message_only(),
-                Some([(RoundId::new(1), RequiredMessageParts::direct_message_only())].into()),
-                Some([RoundId::new(1)].into()),
+                Some([(1.into(), RequiredMessageParts::direct_message_only())].into()),
+                Some([1.into()].into()),
             ),
         }
     }
@@ -58,7 +58,7 @@ impl<Id> ProtocolError<Id> for SimpleProtocolError {
             SimpleProtocolError::Round2InvalidPosition => {
                 let _r1_message = message.direct_message.deserialize::<Round1Message>(deserializer)?;
                 let r1_echos_serialized = combined_echos
-                    .get(&RoundId::new(1))
+                    .get(&1.into())
                     .ok_or_else(|| LocalError::new("Could not find combined echos for Round 1"))?;
 
                 // Deserialize the echos
@@ -84,8 +84,8 @@ impl<Id> Protocol<Id> for SimpleProtocol {
         message: &DirectMessage,
     ) -> Result<(), MessageValidationError> {
         match round_id {
-            r if r == &RoundId::new(1) => message.verify_is_not::<Round1Message>(deserializer),
-            r if r == &RoundId::new(2) => message.verify_is_not::<Round2Message>(deserializer),
+            r if r == &1 => message.verify_is_not::<Round1Message>(deserializer),
+            r if r == &2 => message.verify_is_not::<Round2Message>(deserializer),
             _ => Err(MessageValidationError::InvalidEvidence("Invalid round number".into())),
         }
     }
@@ -96,8 +96,8 @@ impl<Id> Protocol<Id> for SimpleProtocol {
         message: &EchoBroadcast,
     ) -> Result<(), MessageValidationError> {
         match round_id {
-            r if r == &RoundId::new(1) => message.verify_is_some(),
-            r if r == &RoundId::new(2) => message.verify_is_not::<Round2Message>(deserializer),
+            r if r == &1 => message.verify_is_some(),
+            r if r == &2 => message.verify_is_not::<Round2Message>(deserializer),
             _ => Err(MessageValidationError::InvalidEvidence("Invalid round number".into())),
         }
     }
@@ -107,7 +107,7 @@ impl<Id> Protocol<Id> for SimpleProtocol {
         round_id: &RoundId,
         message: &NormalBroadcast,
     ) -> Result<(), MessageValidationError> {
-        if round_id == &RoundId::new(1) || round_id == &RoundId::new(2) {
+        if round_id == &1 || round_id == &2 {
             message.verify_is_some()
         } else {
             Err(MessageValidationError::InvalidEvidence("Invalid round number".into()))
@@ -193,11 +193,11 @@ impl<Id: PartyId> Round<Id> for Round1<Id> {
     type Protocol = SimpleProtocol;
 
     fn id(&self) -> RoundId {
-        RoundId::new(1)
+        1.into()
     }
 
     fn possible_next_rounds(&self) -> BTreeSet<RoundId> {
-        [RoundId::new(2)].into()
+        [2.into()].into()
     }
 
     fn message_destinations(&self) -> &BTreeSet<Id> {
@@ -317,7 +317,7 @@ impl<Id: PartyId> Round<Id> for Round2<Id> {
     type Protocol = SimpleProtocol;
 
     fn id(&self) -> RoundId {
-        RoundId::new(2)
+        2.into()
     }
 
     fn possible_next_rounds(&self) -> BTreeSet<RoundId> {

--- a/examples/src/simple.rs
+++ b/examples/src/simple.rs
@@ -161,6 +161,11 @@ impl<Id: PartyId> SimpleProtocolEntryPoint<Id> {
 
 impl<Id: PartyId> EntryPoint<Id> for SimpleProtocolEntryPoint<Id> {
     type Protocol = SimpleProtocol;
+
+    fn entry_round_id() -> RoundId {
+        1.into()
+    }
+
     fn make_round(
         self,
         _rng: &mut impl CryptoRngCore,

--- a/examples/src/simple_malicious.rs
+++ b/examples/src/simple_malicious.rs
@@ -6,7 +6,7 @@ use manul::{
     dev::{run_sync, BinaryFormat, TestSessionParams, TestSigner},
     protocol::{
         Artifact, BoxedRound, Deserializer, DirectMessage, EntryPoint, LocalError, PartyId, ProtocolMessagePart,
-        RoundId, Serializer,
+        Serializer,
     },
     signature::Keypair,
 };
@@ -37,7 +37,7 @@ impl<Id: PartyId> Misbehaving<Id, Behavior> for MaliciousLogic {
         direct_message: DirectMessage,
         artifact: Option<Artifact>,
     ) -> Result<(DirectMessage, Option<Artifact>), LocalError> {
-        let dm = if round.id() == RoundId::new(1) {
+        let dm = if round.id() == 1 {
             match behavior {
                 Behavior::SerializedGarbage => DirectMessage::new(serializer, [99u8])?,
                 Behavior::AttributableFailure => {
@@ -50,7 +50,7 @@ impl<Id: PartyId> Misbehaving<Id, Behavior> for MaliciousLogic {
                 }
                 _ => direct_message,
             }
-        } else if round.id() == RoundId::new(2) {
+        } else if round.id() == 2 {
             match behavior {
                 Behavior::AttributableFailureRound2 => {
                     let round2 = round.downcast_ref::<Round2<Id>>()?;

--- a/manul/benches/empty_rounds.rs
+++ b/manul/benches/empty_rounds.rs
@@ -73,6 +73,11 @@ struct Round1Artifact;
 
 impl<Id: PartyId> EntryPoint<Id> for Inputs<Id> {
     type Protocol = EmptyProtocol;
+
+    fn entry_round_id() -> RoundId {
+        1.into()
+    }
+
     fn make_round(
         self,
         _rng: &mut impl CryptoRngCore,

--- a/manul/benches/empty_rounds.rs
+++ b/manul/benches/empty_rounds.rs
@@ -90,14 +90,14 @@ impl<Id: PartyId> Round<Id> for EmptyRound<Id> {
     type Protocol = EmptyProtocol;
 
     fn id(&self) -> RoundId {
-        RoundId::new(self.round_counter)
+        self.round_counter.into()
     }
 
     fn possible_next_rounds(&self) -> BTreeSet<RoundId> {
         if self.inputs.rounds_num == self.round_counter {
             BTreeSet::new()
         } else {
-            [RoundId::new(self.round_counter + 1)].into()
+            [(self.round_counter + 1).into()].into()
         }
     }
 

--- a/manul/src/combinators/chain.rs
+++ b/manul/src/combinators/chain.rs
@@ -295,8 +295,8 @@ where
 {
     type Protocol = T::Protocol;
 
-    fn entry_round() -> RoundId {
-        <T as ChainedSplit<Id>>::EntryPoint::entry_round().group_under(1)
+    fn entry_round_id() -> RoundId {
+        <T as ChainedSplit<Id>>::EntryPoint::entry_round_id().group_under(1)
     }
 
     fn make_round(
@@ -368,8 +368,8 @@ where
                     .collect::<BTreeSet<_>>();
 
                 if round.as_ref().may_produce_result() {
-                    tracing::debug!("Adding {}", T::EntryPoint::entry_round().group_under(2));
-                    next_rounds.insert(T::EntryPoint::entry_round().group_under(2));
+                    tracing::debug!("Adding {}", T::EntryPoint::entry_round_id().group_under(2));
+                    next_rounds.insert(T::EntryPoint::entry_round_id().group_under(2));
                 }
 
                 next_rounds

--- a/manul/src/combinators/misbehave.rs
+++ b/manul/src/combinators/misbehave.rs
@@ -138,6 +138,10 @@ where
 {
     type Protocol = <M::EntryPoint as EntryPoint<Id>>::Protocol;
 
+    fn entry_round_id() -> RoundId {
+        M::EntryPoint::entry_round_id()
+    }
+
     fn make_round(
         self,
         rng: &mut impl CryptoRngCore,

--- a/manul/src/protocol/round.rs
+++ b/manul/src/protocol/round.rs
@@ -398,9 +398,7 @@ pub trait EntryPoint<Id: PartyId> {
     type Protocol: Protocol<Id>;
 
     /// Returns the ID of the round returned by [`Self::make_round`].
-    fn entry_round() -> RoundId {
-        RoundId::new(1)
-    }
+    fn entry_round_id() -> RoundId;
 
     /// Creates the round.
     ///

--- a/manul/src/protocol/round.rs
+++ b/manul/src/protocol/round.rs
@@ -142,6 +142,18 @@ impl RoundId {
     }
 }
 
+impl From<u8> for RoundId {
+    fn from(source: u8) -> Self {
+        Self::new(source)
+    }
+}
+
+impl PartialEq<u8> for RoundId {
+    fn eq(&self, rhs: &u8) -> bool {
+        self == &RoundId::new(*rhs)
+    }
+}
+
 /// A distributed protocol.
 pub trait Protocol<Id>: 'static {
     /// The successful result of an execution of this protocol.

--- a/manul/src/tests/partial_echo.rs
+++ b/manul/src/tests/partial_echo.rs
@@ -84,7 +84,7 @@ impl<Id: PartyId + Serialize + for<'de> Deserialize<'de>> Round<Id> for Round1<I
     type Protocol = PartialEchoProtocol<Id>;
 
     fn id(&self) -> RoundId {
-        RoundId::new(1)
+        1.into()
     }
 
     fn possible_next_rounds(&self) -> BTreeSet<RoundId> {

--- a/manul/src/tests/partial_echo.rs
+++ b/manul/src/tests/partial_echo.rs
@@ -70,6 +70,11 @@ struct Round1Echo<Id> {
 
 impl<Id: PartyId + Serialize + for<'de> Deserialize<'de>> EntryPoint<Id> for Inputs<Id> {
     type Protocol = PartialEchoProtocol<Id>;
+
+    fn entry_round_id() -> RoundId {
+        1.into()
+    }
+
     fn make_round(
         self,
         _rng: &mut impl CryptoRngCore,


### PR DESCRIPTION
- added conversion from `u8` to `RoundId` and comparison of `RoundId` with `u8`.
- renamed `Round::entry_round()` to `entry_round_id()` and made it mandatory to implement. This helps avoid bugs when making combinators (like the one fixed in `chain`)