### PR TITLE
Rework `RequiredMessageParts` API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Protocol::verify_*_is_invalid()` are now mandatory to implement. ([#79])
 - Removed the RNG parameter from `Round::receive_message()` and `Session::process_message()`. ([#83])
 - Renamed `Round::entry_round()` to `entry_round_id()` and made it mandatory to implement. ([#84])
+- Rework `RequiredMessageParts` API. ([#85])
 
 
 ### Added
@@ -40,6 +41,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#79]: https://github.com/entropyxyz/manul/pull/79
 [#83]: https://github.com/entropyxyz/manul/pull/83
 [#84]: https://github.com/entropyxyz/manul/pull/84
+[#85]: https://github.com/entropyxyz/manul/pull/85
 
 
 ## [0.1.0] - 2024-11-19

--- a/examples/src/simple.rs
+++ b/examples/src/simple.rs
@@ -28,12 +28,10 @@ impl<Id> ProtocolError<Id> for SimpleProtocolError {
 
     fn required_messages(&self) -> RequiredMessages {
         match self {
-            Self::Round1InvalidPosition => {
-                RequiredMessages::new(RequiredMessageParts::direct_message_only(), None, None)
-            }
+            Self::Round1InvalidPosition => RequiredMessages::new(RequiredMessageParts::direct_message(), None, None),
             Self::Round2InvalidPosition => RequiredMessages::new(
-                RequiredMessageParts::direct_message_only(),
-                Some([(1.into(), RequiredMessageParts::direct_message_only())].into()),
+                RequiredMessageParts::direct_message(),
+                Some([(1.into(), RequiredMessageParts::direct_message())].into()),
                 Some([1.into()].into()),
             ),
         }

--- a/manul/src/protocol/round.rs
+++ b/manul/src/protocol/round.rs
@@ -215,24 +215,34 @@ impl RequiredMessageParts {
         }
     }
 
-    /// Store all parts of the message (echo broadcast, normal broadcast, direct message).
-    pub fn all() -> Self {
-        Self::new(true, true, true)
-    }
-
-    /// Store echo broadcast only.
-    pub fn echo_broadcast_only() -> Self {
+    /// Store echo broadcast
+    pub fn echo_broadcast() -> Self {
         Self::new(true, false, false)
     }
 
-    /// Store normal broadcast only.
-    pub fn normal_broadcast_only() -> Self {
+    /// Store normal broadcast
+    pub fn normal_broadcast() -> Self {
         Self::new(false, true, false)
     }
 
-    /// Store direct message only.
-    pub fn direct_message_only() -> Self {
+    /// Store direct message
+    pub fn direct_message() -> Self {
         Self::new(false, false, true)
+    }
+
+    /// Store echo broadcast in addition to what is already stored.
+    pub fn and_echo_broadcast(&self) -> Self {
+        Self::new(true, self.normal_broadcast, self.direct_message)
+    }
+
+    /// Store normal broadcast in addition to what is already stored.
+    pub fn and_normal_broadcast(&self) -> Self {
+        Self::new(self.echo_broadcast, true, self.direct_message)
+    }
+
+    /// Store direct message in addition to what is already stored.
+    pub fn and_direct_message(&self) -> Self {
+        Self::new(self.echo_broadcast, self.normal_broadcast, true)
     }
 }
 


### PR DESCRIPTION
Make `RequiredMessageParts` API follow a kind of a builder pattern. This leads to:
- somewhat shorter lines when only one part of the message is needed
- allowing to require two out of three parts of the messages