### PR TITLE
Testing fixes

### DIFF
--- a/manul/src/dev/run_sync.rs
+++ b/manul/src/dev/run_sync.rs
@@ -27,6 +27,73 @@ struct RoundMessage<SP: SessionParameters> {
     message: Message<SP::Verifier>,
 }
 
+enum Messages<SP: SessionParameters> {
+    /// For each node, if message A was sent before message B, it will be popped before message B as well.
+    Ordered(BTreeMap<SP::Verifier, Vec<RoundMessage<SP>>>),
+    /// The messages will be popped completely at random.
+    Unordered(Vec<RoundMessage<SP>>),
+}
+
+impl<SP> Messages<SP>
+where
+    SP: SessionParameters,
+{
+    fn new(ordered: bool) -> Self {
+        if ordered {
+            Self::Ordered(BTreeMap::new())
+        } else {
+            Self::Unordered(Vec::new())
+        }
+    }
+
+    /// Adds a message to the queue.
+    fn push(&mut self, message: RoundMessage<SP>) {
+        match self {
+            Self::Ordered(m) => m.entry(message.from.clone()).or_insert(Vec::new()).push(message),
+            Self::Unordered(v) => v.push(message),
+        }
+    }
+
+    /// Adds a a vector of messages to the queue.
+    fn extend(&mut self, messages: Vec<RoundMessage<SP>>) {
+        for message in messages {
+            self.push(message)
+        }
+    }
+
+    /// Removes a random message from the queue and returns it.
+    fn pop(&mut self, rng: &mut impl CryptoRngCore) -> RoundMessage<SP> {
+        match self {
+            Self::Ordered(m) => {
+                let senders = m.keys().cloned().collect::<Vec<_>>();
+                let sender_idx = rng.gen_range(0..senders.len());
+                let sender = &senders.get(sender_idx).expect("the entry exists");
+
+                let (message, is_empty) = {
+                    let messages = m.get_mut(sender).expect("the entry exists");
+                    let message = messages.remove(0);
+                    (message, messages.is_empty())
+                };
+                if is_empty {
+                    m.remove(sender);
+                }
+                message
+            }
+            Self::Unordered(v) => {
+                let message_idx = rng.gen_range(0..v.len());
+                v.swap_remove(message_idx)
+            }
+        }
+    }
+
+    fn is_empty(&self) -> bool {
+        match self {
+            Self::Ordered(m) => m.is_empty(),
+            Self::Unordered(v) => v.is_empty(),
+        }
+    }
+}
+
 #[allow(clippy::type_complexity)]
 fn propagate<P, SP>(
     rng: &mut impl CryptoRngCore,
@@ -98,7 +165,7 @@ where
 {
     let session_id = SessionId::random::<SP>(rng);
 
-    let mut messages = Vec::new();
+    let mut messages = Messages::new(true);
     let mut states = BTreeMap::new();
 
     for (signer, entry_point) in entry_points {
@@ -124,8 +191,7 @@ where
 
     loop {
         // Pick a random message and deliver it
-        let message_idx = rng.gen_range(0..messages.len());
-        let message = messages.swap_remove(message_idx);
+        let message = messages.pop(rng);
 
         debug!("Delivering message from {:?} to {:?}", message.from, message.to);
 

--- a/manul/src/protocol/message.rs
+++ b/manul/src/protocol/message.rs
@@ -67,7 +67,7 @@ pub trait ProtocolMessagePart: ProtocolMessageWrapper {
         if self.is_none() {
             Ok(())
         } else {
-            Err("The payload was expected to contain a message, but is `None`"
+            Err("The payload was expected to be `None`, but contains a message"
                 .to_string()
                 .into())
         }


### PR DESCRIPTION
- Fixed an error message in `ProtocolMessagePart::assert_is_none()` - it was the opposite of what it should have really said
- Cosmetic improvements in `SessionReport::brief()` - do not show parts of the report that have no entries
- Switch to ordered delivery of messages in `run_sync()`

Some details on the latter. When writing tests for invalid echo messages, I noticed that the test sometimes fails without generating an evidence, but rather complaining that an unexpected message was encountered. The full sequence of events was the following:
- A test overrides a round to send out an echo message, where normally a round doesn't send one;
- `Session` for that node sees there's an echo message and assumes there's an echo round
- It finalizes the round and sends out an echo message
- Due to delivery being random, sometimes it gets delivered before the actual round message with the payload that would trigger the expected error
- The other nodes do not expect an echo round, so they return an unprovable error about an unexpected message

It could be fixed by making the user explicitly declare if there's an echo round, regardless of there being an echo broadcast, but that means more boilerplate in every round declaration. Instead I chose to make the message delivery in `run_sync()` ordered (for each node separately), so that the main round message arrives first and triggers the expected error.

The unordered delivery is still valuable for `manul` self-testing, so it is left as an option (although currently not used).

