### PR TITLE
Allow overriding `finalize()` in `Misbehaving`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Exposed `dev::ExecutionResult`. ([#79])
 - `NoProtocolErrors` stub type to indicate that the protocol does not generate any provable errors. ([#79])
 - Conversion from `u8` to `RoundId` and comparison of `RoundId` with `u8`. ([#84])
+- `Misbehaving::override_finalize()` for malicious finalization logic. ([#87])
 
 
 ### Fixed
@@ -48,6 +49,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#84]: https://github.com/entropyxyz/manul/pull/84
 [#85]: https://github.com/entropyxyz/manul/pull/85
 [#86]: https://github.com/entropyxyz/manul/pull/86
+[#87]: https://github.com/entropyxyz/manul/pull/87
 
 
 ## [0.1.0] - 2024-11-19


### PR DESCRIPTION
Stacked on top of #86

This came up in https://github.com/entropyxyz/synedrion/pull/170. In order to test the optional error round in InteractiveSigning, the malicious node needs to be forced to transition into it. But since it only receives valid messages from lawful nodes, it has no reason to. The new `Misbehaving::override_finalize()` allows one to replace the existing `Round::finalize()` with custom logic.