### PR TITLE
Add the `From` impl for `SerializableMap` -> `BTreeMap`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `NoProtocolErrors` stub type to indicate that the protocol does not generate any provable errors. ([#79])
 - Conversion from `u8` to `RoundId` and comparison of `RoundId` with `u8`. ([#84])
 - `Misbehaving::override_finalize()` for malicious finalization logic. ([#87])
+- `From<SerializableMap<K, V>> for BTreeMap<K, V>` impl. ([#88])
 
 
 ### Fixed
@@ -50,6 +51,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#85]: https://github.com/entropyxyz/manul/pull/85
 [#86]: https://github.com/entropyxyz/manul/pull/86
 [#87]: https://github.com/entropyxyz/manul/pull/87
+[#88]: https://github.com/entropyxyz/manul/pull/88
 
 
 ## [0.1.0] - 2024-11-19

--- a/manul/src/utils/serializable_map.rs
+++ b/manul/src/utils/serializable_map.rs
@@ -26,6 +26,12 @@ impl<K, V> From<BTreeMap<K, V>> for SerializableMap<K, V> {
     }
 }
 
+impl<K, V> From<SerializableMap<K, V>> for BTreeMap<K, V> {
+    fn from(source: SerializableMap<K, V>) -> Self {
+        source.0
+    }
+}
+
 impl<K, V> Deref for SerializableMap<K, V> {
     type Target = BTreeMap<K, V>;
 


### PR DESCRIPTION
`Deref` is enough for most cases where we have a serializable structure with a map in it, but sometimes we need to extract the actual `BTreeMap` without cloning.