### PR TITLE
Send hashes in the echo round instead of the full messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - An error message in `ProtocolMessagePart::assert_is_none()`. ([#86])
 - Output size mismatch in `TestHasher`. ([#90])
+- Reduced the size of echo round message by sending hashes instead of full messages. ([#90])
 
 
 [#75]: https://github.com/entropyxyz/manul/pull/75

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - An error message in `ProtocolMessagePart::assert_is_none()`. ([#86])
+- Output size mismatch in `TestHasher`. ([#90])
 
 
 [#75]: https://github.com/entropyxyz/manul/pull/75
@@ -54,6 +55,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#86]: https://github.com/entropyxyz/manul/pull/86
 [#87]: https://github.com/entropyxyz/manul/pull/87
 [#88]: https://github.com/entropyxyz/manul/pull/88
+[#90]: https://github.com/entropyxyz/manul/pull/90
 [#91]: https://github.com/entropyxyz/manul/pull/91
 
 

--- a/manul/src/dev/session_parameters.rs
+++ b/manul/src/dev/session_parameters.rs
@@ -62,7 +62,7 @@ impl<D: digest::Digest> signature::DigestVerifier<D, TestSignature> for TestVeri
 #[derive(Debug, Clone, Copy, Default)]
 pub struct TestHasher {
     cursor: usize,
-    buffer: [u8; 32],
+    buffer: digest::Output<Self>,
 }
 
 impl digest::HashMarker for TestHasher {}
@@ -72,7 +72,7 @@ impl digest::Update for TestHasher {
         // A very simple algorithm for testing, just xor the data in buffer-sized chunks.
         for byte in data {
             *self.buffer.get_mut(self.cursor).expect("index within bounds") ^= byte;
-            self.cursor = (self.cursor + 1) % 32;
+            self.cursor = (self.cursor + 1) % self.buffer.len();
         }
     }
 }
@@ -84,7 +84,7 @@ impl digest::FixedOutput for TestHasher {
 }
 
 impl digest::OutputSizeUser for TestHasher {
-    type OutputSize = typenum::U8;
+    type OutputSize = typenum::U32;
 }
 
 /// An implementation of [`SessionParameters`] using the testing signer/verifier types.

--- a/manul/src/protocol.rs
+++ b/manul/src/protocol.rs
@@ -30,4 +30,5 @@ pub use round::{
 pub use serialization::{Deserializer, Serializer};
 
 pub(crate) use errors::ReceiveErrorType;
+pub(crate) use message::ProtocolMessagePartHashable;
 pub(crate) use object_safe::{BoxedRng, ObjectSafeRound};

--- a/manul/src/session/session.rs
+++ b/manul/src/session/session.rs
@@ -436,8 +436,10 @@ where
         not_enough_messages: bool,
     ) -> Result<SessionReport<P, SP>, LocalError> {
         let round_id = self.round_id();
+        let verifier = self.verifier();
         let transcript = self.transcript.update(
             &round_id,
+            (verifier, self.echo_broadcast),
             accum.echo_broadcasts,
             accum.normal_broadcasts,
             accum.direct_messages,
@@ -478,6 +480,7 @@ where
 
         let transcript = self.transcript.update(
             &round_id,
+            (verifier.clone(), self.echo_broadcast),
             accum.echo_broadcasts,
             accum.normal_broadcasts,
             accum.direct_messages,
@@ -489,7 +492,6 @@ where
         if let Some(echo_round_info) = self.echo_round_info {
             let round = BoxedRound::new_dynamic(EchoRound::<P, SP>::new(
                 verifier,
-                self.echo_broadcast,
                 transcript.echo_broadcasts(&round_id)?,
                 echo_round_info,
                 self.round,


### PR DESCRIPTION
Some echo broadcasts in CGGMP'24 include large structures that scale linearly with the number of nodes, so the corresponding echo round messages would scale quadratically. This PR replaces sending full payloads the second time with just sending payload hashes. The trade-offs are:
- every message needs two hash applications instead of one (hash the payload, then hash (payload hash, metadata))
- more information to keep in the `Evidence` (need to keep the echo messages themselves and the signed hashes)

Also fixes a bug with the `TestHasher` `OutputSize` and `buffer.len()` mismatch. Before this PR the created digest was actually ignored when creating `TestSignature`, so the bug didn't fire.

This approach hashes in two stages when it's technically not necessary (that is, for non-echo messages), but I don't think it leads to any noticeable performance decrease — with most hashes it's the update part that's slow, not the finalize. So the only additional cost is an extra tag pushed into the digest.