### PR TITLE
Add a `session::tokio` module with a convenience function for executing a session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Conversion from `u8` to `RoundId` and comparison of `RoundId` with `u8`. ([#84])
 - `Misbehaving::override_finalize()` for malicious finalization logic. ([#87])
 - `From<SerializableMap<K, V>> for BTreeMap<K, V>` impl. ([#88])
+- `session::tokio` submodule containing functions for executing a session in an async `tokio` environment and supporting types. Gated behind the `tokio` feature. ([#91])
 
 
 ### Fixed
@@ -52,6 +53,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#86]: https://github.com/entropyxyz/manul/pull/86
 [#87]: https://github.com/entropyxyz/manul/pull/87
 [#88]: https://github.com/entropyxyz/manul/pull/88
+[#91]: https://github.com/entropyxyz/manul/pull/91
 
 
 ## [0.1.0] - 2024-11-19

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Misbehaving::override_finalize()` for malicious finalization logic. ([#87])
 - `From<SerializableMap<K, V>> for BTreeMap<K, V>` impl. ([#88])
 - `session::tokio` submodule containing functions for executing a session in an async `tokio` environment and supporting types. Gated behind the `tokio` feature. ([#91])
+- `dev::tokio` submoduloe containing functions for executing multiple sessions in an async `tokio` environment. Gated behind the `tokio` feature. ([#91])
 
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -569,6 +569,7 @@ dependencies = [
  "serde_json",
  "signature",
  "tinyvec",
+ "tokio",
  "tracing",
 ]
 

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -21,5 +21,5 @@ displaydoc = "0.2"
 tokio = { version = "1", features = ["rt", "sync", "time", "macros"] }
 rand = "0.8"
 digest = "0.10"
-manul = { path = "../manul", features = ["dev"] }
+manul = { path = "../manul", features = ["dev", "tokio"] }
 test-log = { version = "0.2", features = ["trace", "color"] }

--- a/examples/tests/async_runner.rs
+++ b/examples/tests/async_runner.rs
@@ -1,134 +1,43 @@
 extern crate alloc;
 
-use alloc::collections::{BTreeMap, BTreeSet};
+use alloc::collections::BTreeSet;
 
 use manul::{
-    dev::{BinaryFormat, TestSessionParams, TestSigner},
-    protocol::Protocol,
-    session::{
-        tokio::{run_session, MessageIn, MessageOut},
-        Session, SessionId, SessionParameters, SessionReport,
-    },
+    dev::{tokio::run_async, BinaryFormat, TestSessionParams, TestSigner},
     signature::Keypair,
 };
-use manul_example::simple::{SimpleProtocol, SimpleProtocolEntryPoint};
-use rand::Rng;
+use manul_example::simple::SimpleProtocolEntryPoint;
 use rand_core::OsRng;
-use tokio::{
-    sync::mpsc,
-    time::{sleep, Duration},
-};
 
-async fn message_dispatcher<SP>(
-    txs: BTreeMap<SP::Verifier, mpsc::Sender<MessageIn<SP>>>,
-    rx: mpsc::Receiver<MessageOut<SP>>,
-) where
-    SP: SessionParameters,
-{
-    let mut rx = rx;
-    let mut messages = Vec::<MessageOut<SP>>::new();
-    loop {
-        let msg = match rx.recv().await {
-            Some(msg) => msg,
-            None => break,
-        };
-        messages.push(msg);
-
-        while let Ok(msg) = rx.try_recv() {
-            messages.push(msg)
-        }
-
-        while !messages.is_empty() {
-            // Pull a random message from the list,
-            // to increase the chances that they are delivered out of order.
-            let message_idx = rand::thread_rng().gen_range(0..messages.len());
-            let outgoing = messages.swap_remove(message_idx);
-
-            txs[&outgoing.to]
-                .send(MessageIn {
-                    from: outgoing.from,
-                    message: outgoing.message,
-                })
-                .await
-                .unwrap();
-
-            // Give up execution so that the tasks could process messages.
-            sleep(Duration::from_millis(0)).await;
-
-            if let Ok(msg) = rx.try_recv() {
-                messages.push(msg);
-            };
-        }
-    }
-}
-
-async fn run_nodes<P, SP>(sessions: Vec<Session<P, SP>>) -> Vec<SessionReport<P, SP>>
-where
-    P: Protocol<SP::Verifier> + Send,
-    SP: SessionParameters,
-    P::Result: Send,
-    SP::Signer: Send,
-{
-    let num_parties = sessions.len();
-
-    let (dispatcher_tx, dispatcher_rx) = mpsc::channel::<MessageOut<SP>>(100);
-
-    let channels = (0..num_parties).map(|_| mpsc::channel::<MessageIn<SP>>(100));
-    let (txs, rxs): (Vec<_>, Vec<_>) = channels.unzip();
-    let tx_map = sessions
-        .iter()
-        .map(|session| session.verifier())
-        .zip(txs.into_iter())
-        .collect();
-
-    let dispatcher_task = message_dispatcher(tx_map, dispatcher_rx);
-    let dispatcher = tokio::spawn(dispatcher_task);
-
-    let handles = rxs
-        .into_iter()
-        .zip(sessions.into_iter())
-        .map(|(mut rx, session)| {
-            let tx = dispatcher_tx.clone();
-            let node_task = async move { run_session(&mut OsRng, &tx, &mut rx, session).await };
-            tokio::spawn(node_task)
-        })
-        .collect::<Vec<_>>();
-
-    // Drop the last copy of the dispatcher's incoming channel so that it can finish.
-    drop(dispatcher_tx);
-
-    let mut results = Vec::with_capacity(num_parties);
-    for handle in handles {
-        results.push(handle.await.unwrap().unwrap());
-    }
-
-    dispatcher.await.unwrap();
-
-    results
-}
-
-#[tokio::test]
-async fn async_run() {
-    // The kind of Session we need to run the `SimpleProtocol`.
-    type SimpleSession = Session<SimpleProtocol, TestSessionParams<BinaryFormat>>;
-
+async fn async_run(offload_processing: bool) {
     // Create 4 parties
     let signers = (0..3).map(TestSigner::new).collect::<Vec<_>>();
     let all_ids = signers
         .iter()
         .map(|signer| signer.verifying_key())
         .collect::<BTreeSet<_>>();
-    let session_id = SessionId::random::<TestSessionParams<BinaryFormat>>(&mut OsRng);
 
-    // Create 4 `Session`s
-    let sessions = signers
+    // Create 4 entry points
+    let entry_points = signers
         .into_iter()
         .map(|signer| {
             let entry_point = SimpleProtocolEntryPoint::new(all_ids.clone());
-            SimpleSession::new(&mut OsRng, session_id.clone(), signer, entry_point).unwrap()
+            (signer, entry_point)
         })
         .collect::<Vec<_>>();
 
     // Run the protocol
-    run_nodes(sessions).await;
+    run_async::<_, TestSessionParams<BinaryFormat>>(&mut OsRng, entry_points, offload_processing)
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn async_run_no_offload() {
+    async_run(false).await
+}
+
+#[tokio::test]
+async fn async_run_with_offload() {
+    async_run(true).await
 }

--- a/manul/Cargo.toml
+++ b/manul/Cargo.toml
@@ -27,6 +27,7 @@ rand = { version = "0.8", default-features = false, optional = true }
 serde-persistent-deserializer = { version = "0.3", optional = true }
 postcard = { version = "1", default-features = false, features = ["alloc"], optional = true }
 serde_json = { version = "1", default-features = false, features = ["alloc"], optional = true }
+tokio = { version = "1", default-features = false, features = ["sync"], optional = true }
 
 [dev-dependencies]
 impls = "1"
@@ -43,6 +44,7 @@ tracing = { version = "0.1", default-features = false, features = ["std"] }
 
 [features]
 dev = ["rand", "postcard", "serde_json", "tracing/std", "serde-persistent-deserializer"]
+tokio = ["dep:tokio"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/manul/Cargo.toml
+++ b/manul/Cargo.toml
@@ -27,7 +27,7 @@ rand = { version = "0.8", default-features = false, optional = true }
 serde-persistent-deserializer = { version = "0.3", optional = true }
 postcard = { version = "1", default-features = false, features = ["alloc"], optional = true }
 serde_json = { version = "1", default-features = false, features = ["alloc"], optional = true }
-tokio = { version = "1", default-features = false, features = ["sync"], optional = true }
+tokio = { version = "1", default-features = false, features = ["sync", "rt", "macros"], optional = true }
 
 [dev-dependencies]
 impls = "1"

--- a/manul/Cargo.toml
+++ b/manul/Cargo.toml
@@ -27,7 +27,7 @@ rand = { version = "0.8", default-features = false, optional = true }
 serde-persistent-deserializer = { version = "0.3", optional = true }
 postcard = { version = "1", default-features = false, features = ["alloc"], optional = true }
 serde_json = { version = "1", default-features = false, features = ["alloc"], optional = true }
-tokio = { version = "1", default-features = false, features = ["sync", "rt", "macros"], optional = true }
+tokio = { version = "1", default-features = false, features = ["sync", "rt", "macros", "time"], optional = true }
 
 [dev-dependencies]
 impls = "1"
@@ -54,3 +54,8 @@ rustdoc-args = ["--cfg", "docsrs"]
 name = "empty_rounds"
 harness = false
 required-features = ["dev"]
+
+[[bench]]
+name = "async_session"
+harness = false
+required-features = ["dev", "tokio"]

--- a/manul/src/dev.rs
+++ b/manul/src/dev.rs
@@ -12,6 +12,9 @@ mod run_sync;
 mod session_parameters;
 mod wire_format;
 
+#[cfg(feature = "tokio")]
+pub mod tokio;
+
 pub use run_sync::{run_sync, ExecutionResult};
 pub use session_parameters::{TestHasher, TestSessionParams, TestSignature, TestSigner, TestVerifier};
 pub use wire_format::{BinaryFormat, HumanReadableFormat};

--- a/manul/src/dev/run_sync.rs
+++ b/manul/src/dev/run_sync.rs
@@ -153,7 +153,7 @@ where
     Ok((state, messages))
 }
 
-/// Execute sessions for multiple nodes concurrently,
+/// Execute sessions for multiple nodes in a single thread,
 /// given a vector of the signer and the entry point as a tuple for each node.
 pub fn run_sync<EP, SP>(
     rng: &mut impl CryptoRngCore,

--- a/manul/src/dev/tokio.rs
+++ b/manul/src/dev/tokio.rs
@@ -1,0 +1,143 @@
+//! `tokio`-specific development utilities.
+
+use alloc::{collections::BTreeMap, format, vec::Vec};
+
+use rand::Rng;
+use rand_core::CryptoRngCore;
+use signature::Keypair;
+use tokio::sync::mpsc;
+
+use super::run_sync::ExecutionResult;
+use crate::{
+    protocol::{EntryPoint, Protocol},
+    session::{
+        tokio::{par_run_session, run_session, MessageIn, MessageOut},
+        LocalError, Session, SessionId, SessionParameters,
+    },
+};
+
+async fn message_dispatcher<SP>(
+    rng: impl CryptoRngCore,
+    txs: BTreeMap<SP::Verifier, mpsc::Sender<MessageIn<SP>>>,
+    rx: mpsc::Receiver<MessageOut<SP>>,
+) -> Result<(), LocalError>
+where
+    SP: SessionParameters,
+{
+    let mut rng = rng;
+
+    let mut rx = rx;
+    let mut messages = Vec::<MessageOut<SP>>::new();
+    loop {
+        let msg = match rx.recv().await {
+            Some(msg) => msg,
+            None => return Ok(()),
+        };
+        messages.push(msg);
+
+        while let Ok(msg) = rx.try_recv() {
+            messages.push(msg)
+        }
+
+        while !messages.is_empty() {
+            // Pull a random message from the list,
+            // to increase the chances that they are delivered out of order.
+            let message_idx = rng.gen_range(0..messages.len());
+            let outgoing = messages.swap_remove(message_idx);
+
+            txs.get(&outgoing.to)
+                .ok_or_else(|| {
+                    LocalError::new(format!(
+                        "Destination ({:?}) is missing in the map of channels",
+                        outgoing.to
+                    ))
+                })?
+                .send(MessageIn {
+                    from: outgoing.from,
+                    message: outgoing.message,
+                })
+                .await
+                .map_err(|err| LocalError::new(format!("Could not sent an outgoing message: {err}")))?;
+
+            // Give up execution so that the tasks could process messages.
+            tokio::time::sleep(tokio::time::Duration::from_millis(0)).await;
+
+            if let Ok(msg) = rx.try_recv() {
+                messages.push(msg);
+            };
+        }
+    }
+}
+
+/// Execute sessions for multiple nodes concurrently within a `tokio` runtime,
+/// given a vector of the signer and the entry point as a tuple for each node.
+///
+/// If `offload_processing` is `true`, message creation and verification will be launched in separate tasks.
+pub async fn run_async<EP, SP>(
+    rng: &mut (impl 'static + CryptoRngCore + Clone + Send),
+    entry_points: Vec<(SP::Signer, EP)>,
+    offload_processing: bool,
+) -> Result<ExecutionResult<EP::Protocol, SP>, LocalError>
+where
+    EP: EntryPoint<SP::Verifier>,
+    SP: SessionParameters,
+    SP::Signer: Send + Sync,
+    <EP::Protocol as Protocol<SP::Verifier>>::ProtocolError: Send + Sync,
+    <EP::Protocol as Protocol<SP::Verifier>>::Result: Send,
+{
+    let num_parties = entry_points.len();
+    let session_id = SessionId::random::<SP>(rng);
+
+    let (dispatcher_tx, dispatcher_rx) = mpsc::channel::<MessageOut<SP>>(100);
+
+    let channels = (0..num_parties).map(|_| mpsc::channel::<MessageIn<SP>>(100));
+    let (txs, rxs): (Vec<_>, Vec<_>) = channels.unzip();
+    let tx_map = entry_points
+        .iter()
+        .map(|(signer, _entry_point)| signer.verifying_key())
+        .zip(txs.into_iter())
+        .collect();
+
+    let dispatcher_task = message_dispatcher(rng.clone(), tx_map, dispatcher_rx);
+    let dispatcher = tokio::spawn(dispatcher_task);
+
+    let handles = rxs
+        .into_iter()
+        .zip(entry_points.into_iter())
+        .map(|(mut rx, (signer, entry_point))| {
+            let tx = dispatcher_tx.clone();
+            let mut rng = rng.clone();
+
+            let session = Session::<_, SP>::new(&mut rng, session_id.clone(), signer, entry_point)?;
+            let id = session.verifier().clone();
+
+            let node_task = async move {
+                if offload_processing {
+                    par_run_session(&mut rng, &tx, &mut rx, session).await
+                } else {
+                    run_session(&mut rng, &tx, &mut rx, session).await
+                }
+            };
+            Ok((id, tokio::spawn(node_task)))
+        })
+        .collect::<Result<BTreeMap<_, _>, _>>()?;
+
+    // Drop the last copy of the dispatcher's incoming channel so that it can finish.
+    drop(dispatcher_tx);
+
+    let mut reports = BTreeMap::new();
+    for (id, handle) in handles {
+        reports.insert(
+            id.clone(),
+            handle
+                .await
+                .map_err(|err| LocalError::new(format!("Could not join the task of {id:?}: {err}")))??,
+        );
+    }
+
+    dispatcher
+        .await
+        .map_err(|err| LocalError::new(format!("Could not join the message dispatcher task: {err}")))??;
+
+    Ok(ExecutionResult { reports })
+}

--- a/manul/src/session.rs
+++ b/manul/src/session.rs
@@ -15,6 +15,9 @@ mod session;
 mod transcript;
 mod wire_format;
 
+#[cfg(feature = "tokio")]
+pub mod tokio;
+
 pub use crate::protocol::{LocalError, RemoteError};
 pub use evidence::{Evidence, EvidenceError};
 pub use message::{Message, VerifiedMessage};

--- a/manul/src/session/tokio.rs
+++ b/manul/src/session/tokio.rs
@@ -1,0 +1,174 @@
+//! High-level API for executing sessions in `tokio` tasks.
+
+use alloc::{format, vec::Vec};
+
+use rand_core::CryptoRngCore;
+use tokio::sync::mpsc;
+use tracing::{debug, trace};
+
+use super::{
+    message::Message,
+    session::{CanFinalize, RoundOutcome, Session, SessionId, SessionParameters},
+    transcript::SessionReport,
+    LocalError,
+};
+use crate::protocol::Protocol;
+
+/// The outgoing message from a local session.
+#[derive(Debug)]
+pub struct MessageOut<SP: SessionParameters> {
+    /// The session ID that created the message.
+    ///
+    /// Useful when there are several sessions running on a node, pushing messages into the same channel.
+    pub session_id: SessionId,
+    /// The verifying key of the party that created the message.
+    ///
+    /// Useful when there are several sessions running on a node, pushing messages into the same channel.
+    pub from: SP::Verifier,
+    /// The verifying key of the party the message is intended for.
+    pub to: SP::Verifier,
+    /// The message to be sent.
+    ///
+    /// Note that the caller is responsible for encrypting the message and attaching authentication info.
+    pub message: Message<SP::Verifier>,
+}
+
+/// The incoming message from a remote session.
+#[derive(Debug)]
+pub struct MessageIn<SP: SessionParameters> {
+    /// The verifying key of the party the message originated from.
+    ///
+    /// It is assumed that the message's authentication info has been checked at this point.
+    pub from: SP::Verifier,
+    /// The incoming message.
+    pub message: Message<SP::Verifier>,
+}
+
+/// Executes the session waiting for the messages from the `rx` channel
+/// and pushing outgoing messages into the `tx` channel.
+pub async fn run_session<P, SP>(
+    rng: &mut impl CryptoRngCore,
+    tx: &mpsc::Sender<MessageOut<SP>>,
+    rx: &mut mpsc::Receiver<MessageIn<SP>>,
+    session: Session<P, SP>,
+) -> Result<SessionReport<P, SP>, LocalError>
+where
+    P: Protocol<SP::Verifier>,
+    SP: SessionParameters,
+{
+    let mut session = session;
+    // Some rounds can finalize early and put off sending messages to the next round. Such messages
+    // will be stored here and applied after the messages for this round are sent.
+    let mut cached_messages = Vec::new();
+
+    let my_id = format!("{:?}", session.verifier());
+
+    // Each iteration of the loop progresses the session as follows:
+    //  - Send out messages as dictated by the session "destinations".
+    //  - Apply any cached messages.
+    //  - Enter a nested loop:
+    //      - Try to finalize the session; if we're done, exit the inner loop.
+    //      - Wait until we get an incoming message.
+    //      - Process the message we received and continue the loop.
+    //  - When all messages have been sent and received as specified by the protocol, finalize the
+    //    round.
+    //  - If the protocol outcome is a new round, go to the top of the loop and start over with a
+    //    new session.
+    loop {
+        debug!("{my_id}: *** starting round {:?} ***", session.round_id());
+
+        // This is kept in the main task since it's mutable,
+        // and we don't want to bother with synchronization.
+        let mut accum = session.make_accumulator();
+
+        // Note: generating/sending messages and verifying newly received messages
+        // can be done in parallel, with the results being assembled into `accum`
+        // sequentially in the host task.
+
+        let destinations = session.message_destinations();
+        for destination in destinations.iter() {
+            // In production usage, this will happen in a spawned task
+            // (since it can take some time to create a message),
+            // and the artifact will be sent back to the host task
+            // to be added to the accumulator.
+            let (message, artifact) = session.make_message(rng, destination)?;
+            debug!("{my_id}: Sending a message to {destination:?}",);
+            tx.send(MessageOut {
+                session_id: session.session_id().clone(),
+                from: session.verifier().clone(),
+                to: destination.clone(),
+                message,
+            })
+            .await
+            .map_err(|err| {
+                LocalError::new(format!(
+                    "Failed to send a message from {:?} to {:?}: {err}",
+                    session.verifier(),
+                    destination
+                ))
+            })?;
+
+            // This would happen in a host task
+            session.add_artifact(&mut accum, artifact)?;
+        }
+
+        for preprocessed in cached_messages {
+            // In production usage, this would happen in a spawned task and relayed back to the main task.
+            debug!("{my_id}: Applying a cached message");
+            let processed = session.process_message(preprocessed);
+
+            // This would happen in a host task.
+            session.add_processed_message(&mut accum, processed)?;
+        }
+
+        loop {
+            match session.can_finalize(&accum) {
+                CanFinalize::Yes => break,
+                CanFinalize::NotYet => {}
+                // Due to already registered invalid messages from nodes,
+                // even if the remaining nodes send correct messages, it won't be enough.
+                // Terminating.
+                CanFinalize::Never => {
+                    tracing::warn!("{my_id}: This session cannot ever be finalized. Terminating.");
+                    return session.terminate_due_to_errors(accum);
+                }
+            }
+
+            debug!("{my_id}: Waiting for a message");
+            let message_in = rx
+                .recv()
+                .await
+                .ok_or_else(|| LocalError::new("Failed to receive a message"))?;
+
+            // Perform quick checks before proceeding with the verification.
+            match session
+                .preprocess_message(&mut accum, &message_in.from, message_in.message)?
+                .ok()
+            {
+                Some(preprocessed) => {
+                    // In production usage, this would happen in a separate task.
+                    debug!("{my_id}: Applying a message from {:?}", message_in.from);
+                    let processed = session.process_message(preprocessed);
+                    // In production usage, this would be a host task.
+                    session.add_processed_message(&mut accum, processed)?;
+                }
+                None => {
+                    trace!("{my_id} Pre-processing complete. Current state: {accum:?}")
+                }
+            }
+        }
+
+        debug!("{my_id}: Finalizing the round");
+
+        match session.finalize_round(rng, accum)? {
+            RoundOutcome::Finished(report) => break Ok(report),
+            RoundOutcome::AnotherRound {
+                session: new_session,
+                cached_messages: new_cached_messages,
+            } => {
+                session = new_session;
+                cached_messages = new_cached_messages;
+            }
+        }
+    }
+}

--- a/manul/src/session/tokio.rs
+++ b/manul/src/session/tokio.rs
@@ -1,14 +1,14 @@
 //! High-level API for executing sessions in `tokio` tasks.
 
-use alloc::{format, vec::Vec};
+use alloc::{format, sync::Arc, vec::Vec};
 
 use rand_core::CryptoRngCore;
-use tokio::sync::mpsc;
+use tokio::{sync::mpsc, task::JoinHandle};
 use tracing::{debug, trace};
 
 use super::{
     message::Message,
-    session::{CanFinalize, RoundOutcome, Session, SessionId, SessionParameters},
+    session::{CanFinalize, ProcessedArtifact, ProcessedMessage, RoundOutcome, Session, SessionId, SessionParameters},
     transcript::SessionReport,
     LocalError,
 };
@@ -167,6 +167,213 @@ where
                 cached_messages: new_cached_messages,
             } => {
                 session = new_session;
+                cached_messages = new_cached_messages;
+            }
+        }
+    }
+}
+
+/// Executes the session waiting for the messages from the `rx` channel
+/// and pushing outgoing messages into the `tx` channel.
+/// The messages are processed in parallel.
+///
+/// This function should be used if message creation and verification takes a significant amount of time,
+/// to offset the parallelizing overhead.
+/// Use [`tokio::run_async`](`crate::dev::tokio::run_async`) to benchmark your specific protocol.
+pub async fn par_run_session<P, SP>(
+    rng: &mut (impl 'static + Clone + CryptoRngCore + Send),
+    tx: &mpsc::Sender<MessageOut<SP>>,
+    rx: &mut mpsc::Receiver<MessageIn<SP>>,
+    session: Session<P, SP>,
+) -> Result<SessionReport<P, SP>, LocalError>
+where
+    P: Protocol<SP::Verifier>,
+    SP: SessionParameters,
+    <SP as SessionParameters>::Signer: Send + Sync,
+    <P as Protocol<SP::Verifier>>::ProtocolError: Send + Sync,
+{
+    let mut session = Arc::new(session);
+    // Some rounds can finalize early and put off sending messages to the next round. Such messages
+    // will be stored here and applied after the messages for this round are sent.
+    let mut cached_messages = Vec::new();
+
+    let my_id = format!("{:?}", session.verifier());
+
+    // Each iteration of the loop progresses the session as follows:
+    //  - Send out messages as dictated by the session "destinations".
+    //  - Apply any cached messages.
+    //  - Enter a nested loop:
+    //      - Try to finalize the session; if we're done, exit the inner loop.
+    //      - Wait until we get an incoming message.
+    //      - Process the message we received and continue the loop.
+    //  - When all messages have been sent and received as specified by the protocol, finalize the
+    //    round.
+    //  - If the protocol outcome is a new round, go to the top of the loop and start over with a
+    //    new session.
+    loop {
+        debug!("{my_id}: *** starting round {:?} ***", session.round_id());
+
+        let (processed_tx, mut processed_rx) = mpsc::channel::<ProcessedMessage<P, SP>>(100);
+        let (outgoing_tx, mut outgoing_rx) = mpsc::channel::<(MessageOut<SP>, ProcessedArtifact<SP>)>(100);
+
+        // This is kept in the main task since it's mutable,
+        // and we don't want to bother with synchronization.
+        let mut accum = session.make_accumulator();
+
+        // Note: generating/sending messages and verifying newly received messages
+        // can be done in parallel, with the results being assembled into `accum`
+        // sequentially in the host task.
+
+        let destinations = session.message_destinations();
+        let mut message_creation_tasks = Vec::new();
+        for destination in destinations {
+            let rng = rng.clone();
+            let session = session.clone();
+            let my_id = my_id.clone();
+            let outgoing_tx = outgoing_tx.clone();
+            let destination = destination.clone();
+            let message_creation = tokio::task::spawn_blocking(move || {
+                let mut rng = rng;
+                let (message, artifact) = session.make_message(&mut rng, &destination)?;
+                debug!("{my_id}: Sending a message to {destination:?}",);
+                let message_out = MessageOut {
+                    session_id: session.session_id().clone(),
+                    from: session.verifier().clone(),
+                    to: destination.clone(),
+                    message,
+                };
+                outgoing_tx.blocking_send((message_out, artifact)).map_err(|err| {
+                    LocalError::new(format!(
+                        "Failed to send a created message from {:?} to {:?}: {err}",
+                        session.verifier(),
+                        destination
+                    ))
+                })
+            });
+            message_creation_tasks.push(message_creation);
+        }
+
+        let mut message_processing_tasks = Vec::new();
+        for preprocessed in cached_messages {
+            let session = session.clone();
+            let processed_tx = processed_tx.clone();
+            let my_id = my_id.clone();
+            let message_processing: JoinHandle<Result<(), LocalError>> = tokio::task::spawn_blocking(move || {
+                debug!("{my_id}: Applying a cached message");
+                let processed = session.process_message(preprocessed);
+                processed_tx
+                    .blocking_send(processed)
+                    .map_err(|_err| LocalError::new("Failed to send a processed message"))
+            });
+            message_processing_tasks.push(message_processing);
+        }
+
+        let can_finalize = loop {
+            match session.can_finalize(&accum) {
+                CanFinalize::Yes => break true,
+                CanFinalize::NotYet => {}
+                // Due to already registered invalid messages from nodes,
+                // even if the remaining nodes send correct messages, it won't be enough.
+                // Terminating.
+                CanFinalize::Never => break false,
+            }
+
+            tokio::select! {
+                processed = processed_rx.recv() => {
+                    if let Some(processed) = processed {
+                        session.add_processed_message(&mut accum, processed)?;
+                    }
+                }
+                outgoing = outgoing_rx.recv() => {
+                    if let Some((message_out, artifact)) = outgoing {
+                        let from = message_out.from.clone();
+                        let to = message_out.to.clone();
+                        tx.send(message_out)
+                        .await
+                        .map_err(|err| {
+                            LocalError::new(format!(
+                                "Failed to send a message from {from:?} to {to:?}: {err}",
+                            ))
+                        })?;
+
+                        session.add_artifact(&mut accum, artifact)?;
+                    }
+                }
+                message_in = rx.recv() => {
+                    if let Some(message_in) = message_in {
+                        match session
+                            .preprocess_message(&mut accum, &message_in.from, message_in.message)?
+                            .ok()
+                        {
+                            Some(preprocessed) => {
+                                let session = session.clone();
+                                let processed_tx = processed_tx.clone();
+                                let my_id = my_id.clone();
+                                let message_processing = tokio::task::spawn_blocking(move || {
+                                    debug!("{my_id}: Applying a message from {:?}", message_in.from);
+                                    let processed = session.process_message(preprocessed);
+                                    processed_tx.blocking_send(processed).map_err(|_err| {
+                                        LocalError::new("Failed to send a processed message")
+                                    })
+                                });
+                                message_processing_tasks.push(message_processing);
+                            }
+                            None => {
+                                trace!("{my_id} Pre-processing complete. Current state: {accum:?}")
+                            }
+                        }
+                    }
+                }
+            }
+        };
+
+        debug!("{my_id}: Finalizing the round {}", session.round_id());
+
+        // Join all the handles created in this iteration.
+
+        for message_creation_task in message_creation_tasks {
+            message_creation_task
+                .await
+                .map_err(|_err| LocalError::new("Failed to join a message creation task"))??;
+        }
+
+        for message_processing_task in message_processing_tasks {
+            message_processing_task
+                .await
+                .map_err(|_err| LocalError::new("Failed to join a message processing task"))??;
+        }
+
+        // Drop our copies of `Sender`s to let the channels close.
+        drop(outgoing_tx);
+        drop(processed_tx);
+
+        // Send all the remaining messages
+        while let Some((message_out, artifact)) = outgoing_rx.recv().await {
+            let from = message_out.from.clone();
+            let to = message_out.to.clone();
+            tx.send(message_out)
+                .await
+                .map_err(|err| LocalError::new(format!("Failed to send a message from {from:?} to {to:?}: {err}",)))?;
+
+            session.add_artifact(&mut accum, artifact)?;
+        }
+
+        debug!("{my_id}: Sent out all remaining messages");
+
+        let session_inner = Arc::into_inner(session)
+            .ok_or_else(|| LocalError::new("There are still references to the session left"))?;
+
+        if !can_finalize {
+            return session_inner.terminate_due_to_errors(accum);
+        }
+
+        match session_inner.finalize_round(rng, accum)? {
+            RoundOutcome::Finished(report) => return Ok(report),
+            RoundOutcome::AnotherRound {
+                session: new_session,
+                cached_messages: new_cached_messages,
+            } => {
+                session = Arc::new(new_session);
                 cached_messages = new_cached_messages;
             }
         }


### PR DESCRIPTION
- Added `session::tokio::run_session()` and supporting types. Gated behind the `tokio` feature. Fixes #28
- Added `session::tokio::par_run_session()` that runs the session with offloading message processing into spawned tasks. Fixes #22 
- Added a benchmark for message offloading
- Moved the async running machinery from `examples/tests/async_runner` into `manul::dev::tokio`

Regarding the info included the channels and included info, for now we will:
- take channels by reference;
- include session ID in the outgoing message (since it can be a sink given to multiple sessions), but not have one in `MessageIn` (since that end of the channel is necessarily personalized)

We will get `entropy-core` to use it and iterate on the results.

There are some weird `Send`/`Sync` bounds, I will attempt to normalize them as a part of #13.