### PR TITLE
`Send`/`Sync` adjustment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Renamed `Round::entry_round()` to `entry_round_id()` and made it mandatory to implement. ([#84])
 - Rework `RequiredMessageParts` API. ([#85])
 - Removed `Send + Sync` bound on `WireFormat`. ([#92])
+- Removed `Send` bound on `ProtocolError`. ([#92])
 
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed the RNG parameter from `Round::receive_message()` and `Session::process_message()`. ([#83])
 - Renamed `Round::entry_round()` to `entry_round_id()` and made it mandatory to implement. ([#84])
 - Rework `RequiredMessageParts` API. ([#85])
+- Removed `Send + Sync` bound on `WireFormat`. ([#92])
 
 
 ### Added
@@ -58,6 +59,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#88]: https://github.com/entropyxyz/manul/pull/88
 [#90]: https://github.com/entropyxyz/manul/pull/90
 [#91]: https://github.com/entropyxyz/manul/pull/91
+[#92]: https://github.com/entropyxyz/manul/pull/92
 
 
 ## [0.1.0] - 2024-11-19

--- a/manul/src/protocol/object_safe.rs
+++ b/manul/src/protocol/object_safe.rs
@@ -96,12 +96,11 @@ pub(crate) trait ObjectSafeRound<Id: PartyId>: 'static + Debug + Send + Sync {
     }
 }
 
-// The `fn(Id) -> Id` bit is so that `ObjectSafeRoundWrapper` didn't require a bound on `Id` to be
-// `Send + Sync`.
+// The `fn(Id)` bit is so that `ObjectSafeRoundWrapper` didn't require a bound on `Id` to be `Send + Sync`.
 #[derive(Debug)]
 pub(crate) struct ObjectSafeRoundWrapper<Id, R> {
     round: R,
-    phantom: PhantomData<fn(Id) -> Id>,
+    phantom: PhantomData<fn(Id)>,
 }
 
 impl<Id, R> ObjectSafeRoundWrapper<Id, R>

--- a/manul/src/protocol/round.rs
+++ b/manul/src/protocol/round.rs
@@ -283,7 +283,7 @@ impl RequiredMessages {
 ///
 /// Provable here means that we can create an evidence object entirely of messages signed by some party,
 /// which, in combination, prove the party's malicious actions.
-pub trait ProtocolError<Id>: Display + Debug + Clone + Send + Serialize + for<'de> Deserialize<'de> {
+pub trait ProtocolError<Id>: Display + Debug + Clone + Serialize + for<'de> Deserialize<'de> {
     /// Additional data that cannot be derived from the node's messages alone
     /// and therefore has to be supplied externally during evidence verification.
     type AssociatedData: Debug;

--- a/manul/src/protocol/serialization.rs
+++ b/manul/src/protocol/serialization.rs
@@ -12,8 +12,9 @@ trait ObjectSafeSerializer: Debug {
     fn serialize(&self, value: Box<dyn erased_serde::Serialize>) -> Result<Box<[u8]>, LocalError>;
 }
 
+// `fn(F)` makes the type `Send` + `Sync` even if `F` isn't.
 #[derive(Debug)]
-struct SerializerWrapper<F: WireFormat>(PhantomData<F>);
+struct SerializerWrapper<F: WireFormat>(PhantomData<fn(F)>);
 
 impl<F: WireFormat> ObjectSafeSerializer for SerializerWrapper<F> {
     fn serialize(&self, value: Box<dyn erased_serde::Serialize>) -> Result<Box<[u8]>, LocalError> {
@@ -42,8 +43,9 @@ impl Serializer {
 
 // Deserialization
 
+// `fn(F)` makes the type `Send` + `Sync` even if `F` isn't.
 #[derive(Debug)]
-struct DeserializerFactoryWrapper<F>(PhantomData<F>);
+struct DeserializerFactoryWrapper<F>(PhantomData<fn(F)>);
 
 trait ObjectSafeDeserializerFactory: Debug {
     fn make_erased_deserializer<'de>(&self, bytes: &'de [u8]) -> Box<dyn erased_serde::Deserializer<'de> + 'de>;
@@ -68,7 +70,7 @@ impl Deserializer {
     where
         F: WireFormat,
     {
-        Self(Box::new(DeserializerFactoryWrapper(PhantomData::<F>)))
+        Self(Box::new(DeserializerFactoryWrapper::<F>(PhantomData)))
     }
 
     /// Deserializes a `serde`-deserializable object.

--- a/manul/src/session/wire_format.rs
+++ b/manul/src/session/wire_format.rs
@@ -25,7 +25,7 @@ if we could instead type-erase the serializer, we wouldn't need that.
 */
 
 /// A (de)serializer that will be used for the protocol messages.
-pub trait WireFormat: 'static + Send + Sync + Debug {
+pub trait WireFormat: 'static + Debug {
     /// Serializes the given object into a bytestring.
     fn serialize<T: Serialize>(value: T) -> Result<Box<[u8]>, LocalError>;
 


### PR DESCRIPTION
- Remove `Send + Sync` bound from `WireFormat`
- Remove `Send` bound on `ProtocolError`

Closes #13. Seems like this is as much as we can do. Since `Round`s are boxed, we can't add `Send + Sync` bounds on them in public API signatures. Same goes for `Payload`s and `Artifact`s. This only really leaves `Protocol`'s and `SessionParameters`s  associated types. `PartyId` is left `Send + Sync` because it is used in `Round` implementations, and specifying that bound every time would just be too much boilerplate.
