### PR TITLE
Merge `Round` methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed `Send + Sync` bound on `WireFormat`. ([#92])
 - Removed `Send` bound on `ProtocolError`. ([#92])
 - Merged `Round::id()`, `possible_next_rounds()` and `may_produce_result()` into `transition_info()`. ([#93])
+- Merged `Round::message_destinations()`, `expecting_messages_from()` and `echo_round_participation()` into `communication_info()`. ([#93])
 
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Rework `RequiredMessageParts` API. ([#85])
 - Removed `Send + Sync` bound on `WireFormat`. ([#92])
 - Removed `Send` bound on `ProtocolError`. ([#92])
+- Merged `Round::id()`, `possible_next_rounds()` and `may_produce_result()` into `transition_info()`. ([#93])
 
 
 ### Added
@@ -61,6 +62,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#90]: https://github.com/entropyxyz/manul/pull/90
 [#91]: https://github.com/entropyxyz/manul/pull/91
 [#92]: https://github.com/entropyxyz/manul/pull/92
+[#93]: https://github.com/entropyxyz/manul/pull/93
 
 
 ## [0.1.0] - 2024-11-19

--- a/examples/src/simple.rs
+++ b/examples/src/simple.rs
@@ -5,7 +5,7 @@ use manul::protocol::{
     Artifact, BoxedRound, Deserializer, DirectMessage, EchoBroadcast, EntryPoint, FinalizeOutcome, LocalError,
     MessageValidationError, NormalBroadcast, PartyId, Payload, Protocol, ProtocolError, ProtocolMessage,
     ProtocolMessagePart, ProtocolValidationError, ReceiveError, RequiredMessageParts, RequiredMessages, Round, RoundId,
-    Serializer,
+    Serializer, TransitionInfo,
 };
 use rand_core::CryptoRngCore;
 use serde::{Deserialize, Serialize};
@@ -195,12 +195,8 @@ impl<Id: PartyId> EntryPoint<Id> for SimpleProtocolEntryPoint<Id> {
 impl<Id: PartyId> Round<Id> for Round1<Id> {
     type Protocol = SimpleProtocol;
 
-    fn id(&self) -> RoundId {
-        1.into()
-    }
-
-    fn possible_next_rounds(&self) -> BTreeSet<RoundId> {
-        [2.into()].into()
+    fn transition_info(&self) -> TransitionInfo {
+        TransitionInfo::new_linear(1)
     }
 
     fn message_destinations(&self) -> &BTreeSet<Id> {
@@ -319,16 +315,8 @@ pub(crate) struct Round2Message {
 impl<Id: PartyId> Round<Id> for Round2<Id> {
     type Protocol = SimpleProtocol;
 
-    fn id(&self) -> RoundId {
-        2.into()
-    }
-
-    fn possible_next_rounds(&self) -> BTreeSet<RoundId> {
-        BTreeSet::new()
-    }
-
-    fn may_produce_result(&self) -> bool {
-        true
+    fn transition_info(&self) -> TransitionInfo {
+        TransitionInfo::new_linear_terminating(2)
     }
 
     fn message_destinations(&self) -> &BTreeSet<Id> {

--- a/examples/src/simple.rs
+++ b/examples/src/simple.rs
@@ -2,8 +2,8 @@ use alloc::collections::{BTreeMap, BTreeSet};
 use core::fmt::Debug;
 
 use manul::protocol::{
-    Artifact, BoxedRound, Deserializer, DirectMessage, EchoBroadcast, EntryPoint, FinalizeOutcome, LocalError,
-    MessageValidationError, NormalBroadcast, PartyId, Payload, Protocol, ProtocolError, ProtocolMessage,
+    Artifact, BoxedRound, CommunicationInfo, Deserializer, DirectMessage, EchoBroadcast, EntryPoint, FinalizeOutcome,
+    LocalError, MessageValidationError, NormalBroadcast, PartyId, Payload, Protocol, ProtocolError, ProtocolMessage,
     ProtocolMessagePart, ProtocolValidationError, ReceiveError, RequiredMessageParts, RequiredMessages, Round, RoundId,
     Serializer, TransitionInfo,
 };
@@ -199,8 +199,8 @@ impl<Id: PartyId> Round<Id> for Round1<Id> {
         TransitionInfo::new_linear(1)
     }
 
-    fn message_destinations(&self) -> &BTreeSet<Id> {
-        &self.context.other_ids
+    fn communication_info(&self) -> CommunicationInfo<Id> {
+        CommunicationInfo::regular(&self.context.other_ids)
     }
 
     fn make_normal_broadcast(
@@ -294,10 +294,6 @@ impl<Id: PartyId> Round<Id> for Round1<Id> {
         });
         Ok(FinalizeOutcome::AnotherRound(round2))
     }
-
-    fn expecting_messages_from(&self) -> &BTreeSet<Id> {
-        &self.context.other_ids
-    }
 }
 
 #[derive(Debug)]
@@ -319,8 +315,8 @@ impl<Id: PartyId> Round<Id> for Round2<Id> {
         TransitionInfo::new_linear_terminating(2)
     }
 
-    fn message_destinations(&self) -> &BTreeSet<Id> {
-        &self.context.other_ids
+    fn communication_info(&self) -> CommunicationInfo<Id> {
+        CommunicationInfo::regular(&self.context.other_ids)
     }
 
     fn make_direct_message(
@@ -381,10 +377,6 @@ impl<Id: PartyId> Round<Id> for Round2<Id> {
             + typed_payloads.iter().map(|payload| payload.x).sum::<u8>();
 
         Ok(FinalizeOutcome::Result(sum + self.round1_sum))
-    }
-
-    fn expecting_messages_from(&self) -> &BTreeSet<Id> {
-        &self.context.other_ids
     }
 }
 

--- a/manul/benches/async_session.rs
+++ b/manul/benches/async_session.rs
@@ -8,9 +8,9 @@ use criterion::{criterion_group, criterion_main, Criterion};
 use manul::{
     dev::{tokio::run_async, BinaryFormat, TestSessionParams, TestSigner},
     protocol::{
-        Artifact, BoxedRound, Deserializer, DirectMessage, EchoBroadcast, EntryPoint, FinalizeOutcome, LocalError,
-        MessageValidationError, NoProtocolErrors, NormalBroadcast, PartyId, Payload, Protocol, ProtocolMessage,
-        ProtocolMessagePart, ReceiveError, Round, RoundId, Serializer, TransitionInfo,
+        Artifact, BoxedRound, CommunicationInfo, Deserializer, DirectMessage, EchoBroadcast, EntryPoint,
+        FinalizeOutcome, LocalError, MessageValidationError, NoProtocolErrors, NormalBroadcast, PartyId, Payload,
+        Protocol, ProtocolMessage, ProtocolMessagePart, ReceiveError, Round, RoundId, Serializer, TransitionInfo,
     },
     signature::Keypair,
 };
@@ -113,8 +113,8 @@ impl<Id: PartyId> Round<Id> for EmptyRound<Id> {
         }
     }
 
-    fn message_destinations(&self) -> &BTreeSet<Id> {
-        &self.inputs.other_ids
+    fn communication_info(&self) -> CommunicationInfo<Id> {
+        CommunicationInfo::regular(&self.inputs.other_ids)
     }
 
     fn make_echo_broadcast(
@@ -184,10 +184,6 @@ impl<Id: PartyId> Round<Id> for EmptyRound<Id> {
             });
             Ok(FinalizeOutcome::AnotherRound(round))
         }
-    }
-
-    fn expecting_messages_from(&self) -> &BTreeSet<Id> {
-        &self.inputs.other_ids
     }
 }
 

--- a/manul/benches/async_session.rs
+++ b/manul/benches/async_session.rs
@@ -10,7 +10,7 @@ use manul::{
     protocol::{
         Artifact, BoxedRound, Deserializer, DirectMessage, EchoBroadcast, EntryPoint, FinalizeOutcome, LocalError,
         MessageValidationError, NoProtocolErrors, NormalBroadcast, PartyId, Payload, Protocol, ProtocolMessage,
-        ProtocolMessagePart, ReceiveError, Round, RoundId, Serializer,
+        ProtocolMessagePart, ReceiveError, Round, RoundId, Serializer, TransitionInfo,
     },
     signature::Keypair,
 };
@@ -105,20 +105,12 @@ impl<Id: PartyId> EntryPoint<Id> for Inputs<Id> {
 impl<Id: PartyId> Round<Id> for EmptyRound<Id> {
     type Protocol = EmptyProtocol;
 
-    fn id(&self) -> RoundId {
-        self.round_counter.into()
-    }
-
-    fn possible_next_rounds(&self) -> BTreeSet<RoundId> {
+    fn transition_info(&self) -> TransitionInfo {
         if self.inputs.rounds_num == self.round_counter {
-            BTreeSet::new()
+            TransitionInfo::new_linear_terminating(self.round_counter)
         } else {
-            [(self.round_counter + 1).into()].into()
+            TransitionInfo::new_linear(self.round_counter)
         }
-    }
-
-    fn may_produce_result(&self) -> bool {
-        self.inputs.rounds_num == self.round_counter
     }
 
     fn message_destinations(&self) -> &BTreeSet<Id> {

--- a/manul/benches/empty_rounds.rs
+++ b/manul/benches/empty_rounds.rs
@@ -9,7 +9,7 @@ use manul::{
     protocol::{
         Artifact, BoxedRound, Deserializer, DirectMessage, EchoBroadcast, EntryPoint, FinalizeOutcome, LocalError,
         MessageValidationError, NoProtocolErrors, NormalBroadcast, PartyId, Payload, Protocol, ProtocolMessage,
-        ProtocolMessagePart, ReceiveError, Round, RoundId, Serializer,
+        ProtocolMessagePart, ReceiveError, Round, RoundId, Serializer, TransitionInfo,
     },
     signature::Keypair,
 };
@@ -94,20 +94,12 @@ impl<Id: PartyId> EntryPoint<Id> for Inputs<Id> {
 impl<Id: PartyId> Round<Id> for EmptyRound<Id> {
     type Protocol = EmptyProtocol;
 
-    fn id(&self) -> RoundId {
-        self.round_counter.into()
-    }
-
-    fn possible_next_rounds(&self) -> BTreeSet<RoundId> {
+    fn transition_info(&self) -> TransitionInfo {
         if self.inputs.rounds_num == self.round_counter {
-            BTreeSet::new()
+            TransitionInfo::new_linear_terminating(self.round_counter)
         } else {
-            [(self.round_counter + 1).into()].into()
+            TransitionInfo::new_linear(self.round_counter)
         }
-    }
-
-    fn may_produce_result(&self) -> bool {
-        self.inputs.rounds_num == self.round_counter
     }
 
     fn message_destinations(&self) -> &BTreeSet<Id> {

--- a/manul/benches/empty_rounds.rs
+++ b/manul/benches/empty_rounds.rs
@@ -7,9 +7,9 @@ use criterion::{criterion_group, criterion_main, Criterion};
 use manul::{
     dev::{run_sync, BinaryFormat, TestSessionParams, TestSigner},
     protocol::{
-        Artifact, BoxedRound, Deserializer, DirectMessage, EchoBroadcast, EntryPoint, FinalizeOutcome, LocalError,
-        MessageValidationError, NoProtocolErrors, NormalBroadcast, PartyId, Payload, Protocol, ProtocolMessage,
-        ProtocolMessagePart, ReceiveError, Round, RoundId, Serializer, TransitionInfo,
+        Artifact, BoxedRound, CommunicationInfo, Deserializer, DirectMessage, EchoBroadcast, EntryPoint,
+        FinalizeOutcome, LocalError, MessageValidationError, NoProtocolErrors, NormalBroadcast, PartyId, Payload,
+        Protocol, ProtocolMessage, ProtocolMessagePart, ReceiveError, Round, RoundId, Serializer, TransitionInfo,
     },
     signature::Keypair,
 };
@@ -102,8 +102,8 @@ impl<Id: PartyId> Round<Id> for EmptyRound<Id> {
         }
     }
 
-    fn message_destinations(&self) -> &BTreeSet<Id> {
-        &self.inputs.other_ids
+    fn communication_info(&self) -> CommunicationInfo<Id> {
+        CommunicationInfo::regular(&self.inputs.other_ids)
     }
 
     fn make_echo_broadcast(
@@ -171,10 +171,6 @@ impl<Id: PartyId> Round<Id> for EmptyRound<Id> {
             });
             Ok(FinalizeOutcome::AnotherRound(round))
         }
-    }
-
-    fn expecting_messages_from(&self) -> &BTreeSet<Id> {
-        &self.inputs.other_ids
     }
 }
 

--- a/manul/src/combinators/chain.rs
+++ b/manul/src/combinators/chain.rs
@@ -62,6 +62,7 @@ use crate::protocol::{
     Artifact, BoxedRng, BoxedRound, Deserializer, DirectMessage, EchoBroadcast, EchoRoundParticipation, EntryPoint,
     FinalizeOutcome, LocalError, MessageValidationError, NormalBroadcast, ObjectSafeRound, PartyId, Payload, Protocol,
     ProtocolError, ProtocolMessage, ProtocolValidationError, ReceiveError, RequiredMessages, RoundId, Serializer,
+    TransitionInfo,
 };
 
 /// A marker trait that is used to disambiguate blanket trait implementations for [`Protocol`] and [`EntryPoint`].
@@ -180,11 +181,11 @@ where
     ) -> Result<(), ProtocolValidationError> {
         let previous_messages = previous_messages
             .into_iter()
-            .map(|(round_id, message)| round_id.ungroup().map(|round_id| (round_id, message)))
+            .map(|(round_id, message)| round_id.split_group().map(|(_group_num, round_id)| (round_id, message)))
             .collect::<Result<BTreeMap<_, _>, _>>()?;
         let combined_echos = combined_echos
             .into_iter()
-            .map(|(round_id, message)| round_id.ungroup().map(|round_id| (round_id, message)))
+            .map(|(round_id, message)| round_id.split_group().map(|(_group_num, round_id)| (round_id, message)))
             .collect::<Result<BTreeMap<_, _>, _>>()?;
 
         match self {
@@ -350,43 +351,17 @@ where
 {
     type Protocol = T::Protocol;
 
-    fn id(&self) -> RoundId {
-        match &self.state {
-            ChainState::Protocol1 { round, .. } => round.as_ref().id().group_under(1),
-            ChainState::Protocol2(round) => round.as_ref().id().group_under(2),
-        }
-    }
-
-    fn possible_next_rounds(&self) -> BTreeSet<RoundId> {
+    fn transition_info(&self) -> TransitionInfo {
         match &self.state {
             ChainState::Protocol1 { round, .. } => {
-                let mut next_rounds = round
-                    .as_ref()
-                    .possible_next_rounds()
-                    .into_iter()
-                    .map(|round_id| round_id.group_under(1))
-                    .collect::<BTreeSet<_>>();
-
-                if round.as_ref().may_produce_result() {
-                    tracing::debug!("Adding {}", T::EntryPoint::entry_round_id().group_under(2));
-                    next_rounds.insert(T::EntryPoint::entry_round_id().group_under(2));
+                let mut tinfo = round.as_ref().transition_info().group_under(1);
+                if tinfo.may_produce_result {
+                    tinfo.may_produce_result = false;
+                    tinfo.children.insert(T::EntryPoint::entry_round_id().group_under(2));
                 }
-
-                next_rounds
+                tinfo
             }
-            ChainState::Protocol2(round) => round
-                .as_ref()
-                .possible_next_rounds()
-                .into_iter()
-                .map(|round_id| round_id.group_under(2))
-                .collect(),
-        }
-    }
-
-    fn may_produce_result(&self) -> bool {
-        match &self.state {
-            ChainState::Protocol1 { .. } => false,
-            ChainState::Protocol2(round) => round.as_ref().may_produce_result(),
+            ChainState::Protocol2(round) => round.as_ref().transition_info().group_under(2),
         }
     }
 

--- a/manul/src/combinators/chain.rs
+++ b/manul/src/combinators/chain.rs
@@ -49,17 +49,14 @@ Usage:
    when verifying evidence from the chained protocol.
 */
 
-use alloc::{
-    boxed::Box,
-    collections::{BTreeMap, BTreeSet},
-};
+use alloc::{boxed::Box, collections::BTreeMap};
 use core::fmt::{self, Debug};
 
 use rand_core::CryptoRngCore;
 use serde::{Deserialize, Serialize};
 
 use crate::protocol::{
-    Artifact, BoxedRng, BoxedRound, Deserializer, DirectMessage, EchoBroadcast, EchoRoundParticipation, EntryPoint,
+    Artifact, BoxedRng, BoxedRound, CommunicationInfo, Deserializer, DirectMessage, EchoBroadcast, EntryPoint,
     FinalizeOutcome, LocalError, MessageValidationError, NormalBroadcast, ObjectSafeRound, PartyId, Payload, Protocol,
     ProtocolError, ProtocolMessage, ProtocolValidationError, ReceiveError, RequiredMessages, RoundId, Serializer,
     TransitionInfo,
@@ -365,24 +362,10 @@ where
         }
     }
 
-    fn message_destinations(&self) -> &BTreeSet<Id> {
+    fn communication_info(&self) -> CommunicationInfo<Id> {
         match &self.state {
-            ChainState::Protocol1 { round, .. } => round.as_ref().message_destinations(),
-            ChainState::Protocol2(round) => round.as_ref().message_destinations(),
-        }
-    }
-
-    fn expecting_messages_from(&self) -> &BTreeSet<Id> {
-        match &self.state {
-            ChainState::Protocol1 { round, .. } => round.as_ref().expecting_messages_from(),
-            ChainState::Protocol2(round) => round.as_ref().expecting_messages_from(),
-        }
-    }
-
-    fn echo_round_participation(&self) -> EchoRoundParticipation<Id> {
-        match &self.state {
-            ChainState::Protocol1 { round, .. } => round.as_ref().echo_round_participation(),
-            ChainState::Protocol2(round) => round.as_ref().echo_round_participation(),
+            ChainState::Protocol1 { round, .. } => round.as_ref().communication_info(),
+            ChainState::Protocol2(round) => round.as_ref().communication_info(),
         }
     }
 

--- a/manul/src/combinators/misbehave.rs
+++ b/manul/src/combinators/misbehave.rs
@@ -34,7 +34,7 @@ use rand_core::CryptoRngCore;
 use crate::protocol::{
     Artifact, BoxedRng, BoxedRound, Deserializer, DirectMessage, EchoBroadcast, EchoRoundParticipation, EntryPoint,
     FinalizeOutcome, LocalError, NormalBroadcast, ObjectSafeRound, PartyId, Payload, Protocol, ProtocolMessage,
-    ReceiveError, RoundId, Serializer,
+    ReceiveError, RoundId, Serializer, TransitionInfo,
 };
 
 /// A trait describing required properties for a behavior type.
@@ -233,16 +233,8 @@ where
 {
     type Protocol = <M::EntryPoint as EntryPoint<Id>>::Protocol;
 
-    fn id(&self) -> RoundId {
-        self.round.as_ref().id()
-    }
-
-    fn possible_next_rounds(&self) -> BTreeSet<RoundId> {
-        self.round.as_ref().possible_next_rounds()
-    }
-
-    fn may_produce_result(&self) -> bool {
-        self.round.as_ref().may_produce_result()
+    fn transition_info(&self) -> TransitionInfo {
+        self.round.as_ref().transition_info()
     }
 
     fn message_destinations(&self) -> &BTreeSet<Id> {

--- a/manul/src/combinators/misbehave.rs
+++ b/manul/src/combinators/misbehave.rs
@@ -23,16 +23,13 @@ Usage:
    as the entry point of the new protocol.
 */
 
-use alloc::{
-    boxed::Box,
-    collections::{BTreeMap, BTreeSet},
-};
+use alloc::{boxed::Box, collections::BTreeMap};
 use core::fmt::Debug;
 
 use rand_core::CryptoRngCore;
 
 use crate::protocol::{
-    Artifact, BoxedRng, BoxedRound, Deserializer, DirectMessage, EchoBroadcast, EchoRoundParticipation, EntryPoint,
+    Artifact, BoxedRng, BoxedRound, CommunicationInfo, Deserializer, DirectMessage, EchoBroadcast, EntryPoint,
     FinalizeOutcome, LocalError, NormalBroadcast, ObjectSafeRound, PartyId, Payload, Protocol, ProtocolMessage,
     ReceiveError, RoundId, Serializer, TransitionInfo,
 };
@@ -237,16 +234,8 @@ where
         self.round.as_ref().transition_info()
     }
 
-    fn message_destinations(&self) -> &BTreeSet<Id> {
-        self.round.as_ref().message_destinations()
-    }
-
-    fn expecting_messages_from(&self) -> &BTreeSet<Id> {
-        self.round.as_ref().expecting_messages_from()
-    }
-
-    fn echo_round_participation(&self) -> EchoRoundParticipation<Id> {
-        self.round.as_ref().echo_round_participation()
+    fn communication_info(&self) -> CommunicationInfo<Id> {
+        self.round.as_ref().communication_info()
     }
 
     fn make_direct_message(

--- a/manul/src/protocol.rs
+++ b/manul/src/protocol.rs
@@ -2,7 +2,7 @@
 API for protocol implementors.
 
 A protocol is a directed acyclic graph with the nodes being objects of types implementing [`Round`]
-(to be specific, "acyclic" means that the values returned by [`Round::id`]
+(to be specific, "acyclic" means that the values returned in the `id` field of [`TransitionInfo`]
 should not repeat during the protocol execution; the types might).
 The starting point is a type that implements [`EntryPoint`].
 All the rounds must have their associated type [`Round::Protocol`] set to the same [`Protocol`] instance
@@ -15,6 +15,7 @@ mod errors;
 mod message;
 mod object_safe;
 mod round;
+mod round_id;
 mod serialization;
 
 pub use errors::{
@@ -25,8 +26,9 @@ pub use message::{DirectMessage, EchoBroadcast, NormalBroadcast, ProtocolMessage
 pub use object_safe::BoxedRound;
 pub use round::{
     Artifact, EchoRoundParticipation, EntryPoint, FinalizeOutcome, NoProtocolErrors, PartyId, Payload, Protocol,
-    ProtocolError, RequiredMessageParts, RequiredMessages, Round, RoundId,
+    ProtocolError, RequiredMessageParts, RequiredMessages, Round,
 };
+pub use round_id::{RoundId, TransitionInfo};
 pub use serialization::{Deserializer, Serializer};
 
 pub(crate) use errors::ReceiveErrorType;

--- a/manul/src/protocol.rs
+++ b/manul/src/protocol.rs
@@ -25,8 +25,8 @@ pub use errors::{
 pub use message::{DirectMessage, EchoBroadcast, NormalBroadcast, ProtocolMessage, ProtocolMessagePart};
 pub use object_safe::BoxedRound;
 pub use round::{
-    Artifact, EchoRoundParticipation, EntryPoint, FinalizeOutcome, NoProtocolErrors, PartyId, Payload, Protocol,
-    ProtocolError, RequiredMessageParts, RequiredMessages, Round,
+    Artifact, CommunicationInfo, EchoRoundParticipation, EntryPoint, FinalizeOutcome, NoProtocolErrors, PartyId,
+    Payload, Protocol, ProtocolError, RequiredMessageParts, RequiredMessages, Round,
 };
 pub use round_id::{RoundId, TransitionInfo};
 pub use serialization::{Deserializer, Serializer};

--- a/manul/src/protocol/object_safe.rs
+++ b/manul/src/protocol/object_safe.rs
@@ -1,8 +1,4 @@
-use alloc::{
-    boxed::Box,
-    collections::{BTreeMap, BTreeSet},
-    format,
-};
+use alloc::{boxed::Box, collections::BTreeMap, format};
 use core::{fmt::Debug, marker::PhantomData};
 
 use rand_core::{CryptoRng, CryptoRngCore, RngCore};
@@ -10,7 +6,7 @@ use rand_core::{CryptoRng, CryptoRngCore, RngCore};
 use super::{
     errors::{LocalError, ReceiveError},
     message::{DirectMessage, EchoBroadcast, NormalBroadcast, ProtocolMessage},
-    round::{Artifact, EchoRoundParticipation, FinalizeOutcome, PartyId, Payload, Protocol, Round},
+    round::{Artifact, CommunicationInfo, FinalizeOutcome, PartyId, Payload, Protocol, Round},
     round_id::{RoundId, TransitionInfo},
     serialization::{Deserializer, Serializer},
 };
@@ -45,11 +41,7 @@ pub(crate) trait ObjectSafeRound<Id: PartyId>: 'static + Debug + Send + Sync {
 
     fn transition_info(&self) -> TransitionInfo;
 
-    fn message_destinations(&self) -> &BTreeSet<Id>;
-
-    fn expecting_messages_from(&self) -> &BTreeSet<Id>;
-
-    fn echo_round_participation(&self) -> EchoRoundParticipation<Id>;
+    fn communication_info(&self) -> CommunicationInfo<Id>;
 
     fn make_direct_message(
         &self,
@@ -124,16 +116,8 @@ where
         self.round.transition_info()
     }
 
-    fn message_destinations(&self) -> &BTreeSet<Id> {
-        self.round.message_destinations()
-    }
-
-    fn expecting_messages_from(&self) -> &BTreeSet<Id> {
-        self.round.expecting_messages_from()
-    }
-
-    fn echo_round_participation(&self) -> EchoRoundParticipation<Id> {
-        self.round.echo_round_participation()
+    fn communication_info(&self) -> CommunicationInfo<Id> {
+        self.round.communication_info()
     }
 
     fn make_direct_message(

--- a/manul/src/protocol/round_id.rs
+++ b/manul/src/protocol/round_id.rs
@@ -1,0 +1,258 @@
+use alloc::collections::BTreeSet;
+use core::fmt::{self, Debug, Display};
+
+use serde::{Deserialize, Serialize};
+use tinyvec::TinyVec;
+
+use super::errors::LocalError;
+
+/// A round identifier.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+pub struct RoundId {
+    round_nums: TinyVec<[u8; 4]>,
+    is_echo: bool,
+}
+
+impl Display for RoundId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
+        write!(f, "Round ")?;
+        for (i, round_num) in self.round_nums.iter().enumerate().rev() {
+            write!(f, "{}", round_num)?;
+            if i != 0 {
+                write!(f, "-")?;
+            }
+        }
+        if self.is_echo {
+            write!(f, " (echo)")?;
+        }
+        Ok(())
+    }
+}
+
+impl RoundId {
+    /// Creates a new round identifier.
+    pub fn new(round_num: u8) -> Self {
+        let mut round_nums = TinyVec::new();
+        round_nums.push(round_num);
+        Self {
+            round_nums,
+            is_echo: false,
+        }
+    }
+
+    /// Prefixes this round ID (possibly already nested) with a group number.
+    ///
+    /// This is supposed to be used internally, e.g. in the chain combinator,
+    /// where we have several protocols joined up, and their round numbers may repeat.
+    /// Grouping allows us to disambiguate them, assigning group 1 to one protocol and group 2 to the other.
+    pub(crate) fn group_under(&self, round_num: u8) -> Self {
+        let mut round_nums = self.round_nums.clone();
+        round_nums.push(round_num);
+        Self {
+            round_nums,
+            is_echo: self.is_echo,
+        }
+    }
+
+    /// Removes the top group prefix from this round ID
+    /// and returns this prefix along with the resulting round ID.
+    ///
+    /// Returns the `Err` variant if the round ID is not nested.
+    pub(crate) fn split_group(&self) -> Result<(u8, Self), LocalError> {
+        if self.round_nums.len() == 1 {
+            Err(LocalError::new("This round ID is not in a group"))
+        } else {
+            let mut round_nums = self.round_nums.clone();
+            let group = round_nums.pop().expect("vector size greater than 1");
+            let round_id = Self {
+                round_nums,
+                is_echo: self.is_echo,
+            };
+            Ok((group, round_id))
+        }
+    }
+
+    /// Returns `true` if this is an ID of an echo broadcast round.
+    pub(crate) fn is_echo(&self) -> bool {
+        self.is_echo
+    }
+
+    /// Returns the identifier of the echo round corresponding to the given non-echo round.
+    ///
+    /// Panics if `self` is already an echo round identifier.
+    pub(crate) fn echo(&self) -> Result<Self, LocalError> {
+        // If this panic happens, there is something wrong with the internal logic
+        // of managing echo-broadcast rounds.
+        if self.is_echo {
+            Err(LocalError::new("This is already an echo round ID"))
+        } else {
+            Ok(Self {
+                round_nums: self.round_nums.clone(),
+                is_echo: true,
+            })
+        }
+    }
+
+    /// Returns the identifier of the non-echo round corresponding to the given echo round.
+    ///
+    /// Panics if `self` is already a non-echo round identifier.
+    pub(crate) fn non_echo(&self) -> Result<Self, LocalError> {
+        // If this panic happens, there is something wrong with the internal logic
+        // of managing echo-broadcast rounds.
+        if !self.is_echo {
+            Err(LocalError::new("This is already an non-echo round ID"))
+        } else {
+            Ok(Self {
+                round_nums: self.round_nums.clone(),
+                is_echo: false,
+            })
+        }
+    }
+}
+
+impl From<u8> for RoundId {
+    fn from(source: u8) -> Self {
+        Self::new(source)
+    }
+}
+
+impl PartialEq<u8> for RoundId {
+    fn eq(&self, rhs: &u8) -> bool {
+        self == &RoundId::new(*rhs)
+    }
+}
+
+/// Information about the position of the round in the state transition graph.
+#[derive(Debug, Clone)]
+pub struct TransitionInfo {
+    /// The round ID.
+    ///
+    /// **Note:** these should not repeat within the same protocol.
+    /// That is, the graph of transitions between rounds must be acyclic.
+    pub id: RoundId,
+
+    /// Round IDs of the rounds that can finalize into this round.
+    pub parents: BTreeSet<RoundId>,
+
+    /// Round IDs of the other rounds that the parents of this round can finalize into.
+    ///
+    /// For example, a round can be followed either by a happy path round or an error round,
+    /// depending on the outcome of some checks during the finalization.
+    pub siblings: BTreeSet<RoundId>,
+
+    /// The round IDs of the rounds this round can finalize into.
+    ///
+    /// Returns an empty set if this round only finalizes into a result.
+    pub children: BTreeSet<RoundId>,
+
+    /// `true` if this round's [`Round::finalize`](`crate::protocol::Round::finalize`)
+    /// may return [`FinalizeOutcome::Result`](`crate::protocol::FinalizeOutcome::Result`).
+    pub may_produce_result: bool,
+}
+
+impl TransitionInfo {
+    /// Nest the round IDs under the given group. Used for combinators.
+    pub(crate) fn group_under(self, group: u8) -> Self {
+        Self {
+            id: self.id.group_under(group),
+            parents: self.parents.into_iter().map(|r| r.group_under(group)).collect(),
+            siblings: self.siblings.into_iter().map(|r| r.group_under(group)).collect(),
+            children: self.children.into_iter().map(|r| r.group_under(group)).collect(),
+            may_produce_result: self.may_produce_result,
+        }
+    }
+
+    /// Returns the set of round IDs that can be simultaneously active on other nodes
+    /// (not including the current round ID).
+    ///
+    /// This includes: the child rounds (if some nodes already finalized this round),
+    /// the parent rounds (if those nodes still are not finalized while we already are),
+    /// and the sibling rounds (if some nodes went on a different path).
+    pub(crate) fn simultaneous_rounds(&self, followed_by_echo_round: bool) -> Result<BTreeSet<RoundId>, LocalError> {
+        let mut result = if followed_by_echo_round {
+            BTreeSet::from([self.id.echo()?])
+        } else {
+            self.parents.clone()
+        };
+        result.extend(self.siblings.iter().cloned());
+        result.extend(self.children.iter().cloned());
+        Ok(result)
+    }
+
+    pub(crate) fn id(&self) -> RoundId {
+        self.id.clone()
+    }
+
+    /// Returns the corresponding transition info for the echo round following this one.
+    pub(crate) fn echo(self) -> Result<Self, LocalError> {
+        Ok(Self {
+            id: self.id.echo()?,
+            parents: [self.id.clone()].into(),
+            siblings: [].into(),
+            children: self.children,
+            may_produce_result: self.may_produce_result,
+        })
+    }
+
+    /// Creates a transition info for a non-terminating round in a linear sequence of rounds starting with 1.
+    ///
+    /// That is, if there are rounds 1, 2, 3, ..., N, where the N-th one returns the result,
+    /// this constructor can be used for rounds 1 to N-1.
+    pub fn new_linear(round_num: u8) -> Self {
+        Self {
+            id: RoundId::new(round_num),
+            parents: if round_num > 1 {
+                [RoundId::new(round_num - 1)].into()
+            } else {
+                [].into()
+            },
+            siblings: [].into(),
+            children: [RoundId::new(round_num + 1)].into(),
+            may_produce_result: false,
+        }
+    }
+
+    /// Creates a transition info for the result round in a linear sequence of rounds starting with 1.
+    ///
+    /// That is, if there are rounds 1, 2, 3, ..., N, where the N-th one returns the result,
+    /// this constructor can be used for round N.
+    pub fn new_linear_terminating(round_num: u8) -> Self {
+        Self {
+            id: RoundId::new(round_num),
+            parents: if round_num > 1 {
+                [RoundId::new(round_num - 1)].into()
+            } else {
+                [].into()
+            },
+            siblings: [].into(),
+            children: [].into(),
+            may_produce_result: true,
+        }
+    }
+
+    /// Returns a new transition info with `round_nums` added to the set of children.
+    pub fn with_children(self, round_nums: BTreeSet<u8>) -> Self {
+        let mut children = self.children;
+        children.extend(round_nums.iter().map(|num| RoundId::new(*num)));
+        Self {
+            id: self.id,
+            parents: self.parents,
+            siblings: self.siblings,
+            children,
+            may_produce_result: self.may_produce_result,
+        }
+    }
+
+    /// Returns a new transition info with `round_nums` added to the set of siblings.
+    pub fn with_siblings(self, round_nums: BTreeSet<u8>) -> Self {
+        let mut siblings = self.siblings;
+        siblings.extend(round_nums.iter().map(|num| RoundId::new(*num)));
+        Self {
+            id: self.id,
+            parents: self.parents,
+            siblings,
+            children: self.children,
+            may_produce_result: self.may_produce_result,
+        }
+    }
+}

--- a/manul/src/session/echo.rs
+++ b/manul/src/session/echo.rs
@@ -18,8 +18,8 @@ use super::{
 use crate::{
     protocol::{
         Artifact, BoxedRound, Deserializer, DirectMessage, EchoBroadcast, FinalizeOutcome, MessageValidationError,
-        NormalBroadcast, Payload, Protocol, ProtocolMessage, ProtocolMessagePart, ReceiveError, Round, RoundId,
-        Serializer,
+        NormalBroadcast, Payload, Protocol, ProtocolMessage, ProtocolMessagePart, ReceiveError, Round, Serializer,
+        TransitionInfo,
     },
     utils::SerializableMap,
 };
@@ -126,12 +126,16 @@ where
 {
     type Protocol = P;
 
-    fn id(&self) -> RoundId {
-        self.main_round.id().echo()
-    }
-
-    fn possible_next_rounds(&self) -> BTreeSet<RoundId> {
-        self.main_round.as_ref().possible_next_rounds()
+    fn transition_info(&self) -> TransitionInfo {
+        // We expect the echo round to be created internally from a regular round,
+        // which cannot be an echo round.
+        // Returning an error here would require allowing the trait method to fail,
+        // which is not needed by any protocol implementors.
+        self.main_round
+            .as_ref()
+            .transition_info()
+            .echo()
+            .expect("the main round is not an echo round")
     }
 
     fn message_destinations(&self) -> &BTreeSet<SP::Verifier> {

--- a/manul/src/tests/partial_echo.rs
+++ b/manul/src/tests/partial_echo.rs
@@ -11,9 +11,10 @@ use serde::{Deserialize, Serialize};
 use crate::{
     dev::{run_sync, BinaryFormat, TestSessionParams, TestSigner, TestVerifier},
     protocol::{
-        Artifact, BoxedRound, Deserializer, DirectMessage, EchoBroadcast, EchoRoundParticipation, EntryPoint,
-        FinalizeOutcome, LocalError, MessageValidationError, NoProtocolErrors, NormalBroadcast, PartyId, Payload,
-        Protocol, ProtocolMessage, ProtocolMessagePart, ReceiveError, Round, RoundId, Serializer, TransitionInfo,
+        Artifact, BoxedRound, CommunicationInfo, Deserializer, DirectMessage, EchoBroadcast, EchoRoundParticipation,
+        EntryPoint, FinalizeOutcome, LocalError, MessageValidationError, NoProtocolErrors, NormalBroadcast, PartyId,
+        Payload, Protocol, ProtocolMessage, ProtocolMessagePart, ReceiveError, Round, RoundId, Serializer,
+        TransitionInfo,
     },
     signature::Keypair,
 };
@@ -92,16 +93,12 @@ impl<Id: PartyId + Serialize + for<'de> Deserialize<'de>> Round<Id> for Round1<I
         TransitionInfo::new_linear_terminating(1)
     }
 
-    fn message_destinations(&self) -> &BTreeSet<Id> {
-        &self.inputs.message_destinations
-    }
-
-    fn expecting_messages_from(&self) -> &BTreeSet<Id> {
-        &self.inputs.expecting_messages_from
-    }
-
-    fn echo_round_participation(&self) -> EchoRoundParticipation<Id> {
-        self.inputs.echo_round_participation.clone()
+    fn communication_info(&self) -> CommunicationInfo<Id> {
+        CommunicationInfo {
+            message_destinations: self.inputs.message_destinations.clone(),
+            expecting_messages_from: self.inputs.expecting_messages_from.clone(),
+            echo_round_participation: self.inputs.echo_round_participation.clone(),
+        }
     }
 
     fn make_echo_broadcast(

--- a/manul/src/tests/partial_echo.rs
+++ b/manul/src/tests/partial_echo.rs
@@ -13,7 +13,7 @@ use crate::{
     protocol::{
         Artifact, BoxedRound, Deserializer, DirectMessage, EchoBroadcast, EchoRoundParticipation, EntryPoint,
         FinalizeOutcome, LocalError, MessageValidationError, NoProtocolErrors, NormalBroadcast, PartyId, Payload,
-        Protocol, ProtocolMessage, ProtocolMessagePart, ReceiveError, Round, RoundId, Serializer,
+        Protocol, ProtocolMessage, ProtocolMessagePart, ReceiveError, Round, RoundId, Serializer, TransitionInfo,
     },
     signature::Keypair,
 };
@@ -88,12 +88,8 @@ impl<Id: PartyId + Serialize + for<'de> Deserialize<'de>> EntryPoint<Id> for Inp
 impl<Id: PartyId + Serialize + for<'de> Deserialize<'de>> Round<Id> for Round1<Id> {
     type Protocol = PartialEchoProtocol<Id>;
 
-    fn id(&self) -> RoundId {
-        1.into()
-    }
-
-    fn possible_next_rounds(&self) -> BTreeSet<RoundId> {
-        BTreeSet::new()
+    fn transition_info(&self) -> TransitionInfo {
+        TransitionInfo::new_linear_terminating(1)
     }
 
     fn message_destinations(&self) -> &BTreeSet<Id> {


### PR DESCRIPTION
- Merge `Round::id()`, `possible_next_rounds()` and `may_produce_result()` into `transition_info()`. Fixes #78
- Merge `Round::message_destinations()`, `expecting_messages_from()` and `echo_round_participation()` into `communication_info()`. With the previous item, fixes #69.