### PR TITLE
Add `impl FromIterator` for `SerializableMap`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `From<SerializableMap<K, V>> for BTreeMap<K, V>` impl. ([#88])
 - `session::tokio` submodule containing functions for executing a session in an async `tokio` environment and supporting types. Gated behind the `tokio` feature. ([#91])
 - `dev::tokio` submoduloe containing functions for executing multiple sessions in an async `tokio` environment. Gated behind the `tokio` feature. ([#91])
+- `impl FromIterator` for `SerializableMap`. ([#97])
 
 
 ### Fixed
@@ -68,6 +69,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#92]: https://github.com/entropyxyz/manul/pull/92
 [#93]: https://github.com/entropyxyz/manul/pull/93
 [#94]: https://github.com/entropyxyz/manul/pull/94
+[#97]: https://github.com/entropyxyz/manul/pull/97
 
 
 ## [0.1.0] - 2024-11-19

--- a/manul/src/lib.rs
+++ b/manul/src/lib.rs
@@ -1,4 +1,4 @@
-#![no_std]
+#![cfg_attr(not(feature = "tokio"), no_std)]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 #![doc = include_str!("../README.md")]
 #![warn(

--- a/manul/src/utils/serializable_map.rs
+++ b/manul/src/utils/serializable_map.rs
@@ -32,6 +32,15 @@ impl<K, V> From<SerializableMap<K, V>> for BTreeMap<K, V> {
     }
 }
 
+impl<K, V> FromIterator<(K, V)> for SerializableMap<K, V>
+where
+    K: Ord,
+{
+    fn from_iter<T: IntoIterator<Item = (K, V)>>(iter: T) -> Self {
+        Self(BTreeMap::from_iter(iter))
+    }
+}
+
 impl<K, V> Deref for SerializableMap<K, V> {
     type Target = BTreeMap<K, V>;
 
@@ -189,5 +198,13 @@ mod tests {
             json_deserialize::<SerializableMap<u8, u8>>(&not_map_serialized).unwrap_err(),
             "invalid type: integer `1`, expected A map serialized as a list of pairs at line 1 column 1"
         );
+    }
+
+    #[test]
+    fn collect() {
+        let x = [(1u8, 2u8), (2, 3)];
+        let smap: SerializableMap<_, _> = x.into_iter().collect();
+        let map: BTreeMap<_, _> = x.into_iter().collect();
+        assert_eq!(smap, SerializableMap::from(map));
     }
 }


### PR DESCRIPTION
Disabling `no_std` for `tokio` featured is required for `tokio::select` to work (which was causing `cargo-semver-check` failures). `tokio::select` was introduced in #91 but somehow `cargo-semver-check` worked before.