### PR TITLE
Add cancellation support to `session::tokio` functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [0.3.0] - in development
+
+### Changed
+
+- `session::tokio::run_session()` and `par_run_session()` take an additional `cancellation` argument to support external loop cancellation. ([#100])
+
+
+[#100]: https://github.com/entropyxyz/manul/pull/100
+
+
 ## [0.2.1] - 2025-05-05
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -145,6 +145,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
+name = "bytes"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
+
+[[package]]
 name = "cast"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -394,6 +400,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures-core"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+
+[[package]]
+name = "futures-sink"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -551,7 +569,7 @@ checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 
 [[package]]
 name = "manul"
-version = "0.2.1"
+version = "0.3.0-dev"
 dependencies = [
  "criterion",
  "derive-where",
@@ -570,6 +588,7 @@ dependencies = [
  "signature",
  "tinyvec",
  "tokio",
+ "tokio-util",
  "tracing",
 ]
 
@@ -1065,6 +1084,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66a539a9ad6d5d281510d5bd368c973d636c02dbf8a67300bfb6b950696ad7df"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]

--- a/manul/Cargo.toml
+++ b/manul/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "manul"
-version = "0.2.1"
+version = "0.3.0-dev"
 edition = "2021"
 rust-version = "1.81"
 authors = ['Entropy Cryptography <engineering@entropy.xyz>']
@@ -28,6 +28,7 @@ serde-persistent-deserializer = { version = "0.3", optional = true }
 postcard = { version = "1", default-features = false, features = ["alloc"], optional = true }
 serde_json = { version = "1", default-features = false, features = ["alloc"], optional = true }
 tokio = { version = "1", default-features = false, features = ["sync", "rt", "macros", "time"], optional = true }
+tokio-util = { version = "0.7", default-features = false, optional = true }
 
 [dev-dependencies]
 impls = "1"
@@ -44,7 +45,7 @@ tracing = { version = "0.1", default-features = false, features = ["std"] }
 
 [features]
 dev = ["rand", "postcard", "serde_json", "tracing/std", "serde-persistent-deserializer"]
-tokio = ["dep:tokio"]
+tokio = ["dep:tokio", "tokio-util"]
 
 [package.metadata.docs.rs]
 all-features = true


### PR DESCRIPTION
This should allow users to impose an external timeout (or to cancel the session loop manually, e.g. on keyboard interrupt). 

Also fixed some error processing lapses in `par_run_session()` where closing of the incoming message channel (or internal channels) was silently ignored.

The timeout support (#12) is still under consideration. The cancellation takes care of the global timeout, or any other cases where the execution needs to be terminated gracefully, but we may still need some partial cutoff times for specific rounds (not clear at this point what the API would be).