### PR TITLE
Re-seed the RNG before spawning

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -579,6 +579,7 @@ dependencies = [
  "impls",
  "postcard",
  "rand",
+ "rand_chacha",
  "rand_core",
  "serde",
  "serde-encoded-bytes",

--- a/manul/Cargo.toml
+++ b/manul/Cargo.toml
@@ -17,6 +17,7 @@ serde-encoded-bytes = { version = "0.2", default-features = false, features = ["
 digest = { version = "0.10", default-features = false }
 signature = { version = "2", default-features = false, features = ["digest", "rand_core"] }
 rand_core = { version = "0.6.4", default-features = false }
+rand_chacha = { version = "0.3", default-features = false }
 tracing = { version = "0.1", default-features = false }
 displaydoc = { version = "0.2", default-features = false }
 derive-where = "1"

--- a/manul/Cargo.toml
+++ b/manul/Cargo.toml
@@ -17,7 +17,7 @@ serde-encoded-bytes = { version = "0.2", default-features = false, features = ["
 digest = { version = "0.10", default-features = false }
 signature = { version = "2", default-features = false, features = ["digest", "rand_core"] }
 rand_core = { version = "0.6.4", default-features = false }
-rand_chacha = { version = "0.3", default-features = false }
+
 tracing = { version = "0.1", default-features = false }
 displaydoc = { version = "0.2", default-features = false }
 derive-where = "1"
@@ -30,6 +30,7 @@ postcard = { version = "1", default-features = false, features = ["alloc"], opti
 serde_json = { version = "1", default-features = false, features = ["alloc"], optional = true }
 tokio = { version = "1", default-features = false, features = ["sync", "rt", "macros", "time"], optional = true }
 tokio-util = { version = "0.7", default-features = false, optional = true }
+rand_chacha = { version = "0.3", default-features = false, optional = true }
 
 [dev-dependencies]
 impls = "1"
@@ -46,7 +47,7 @@ tracing = { version = "0.1", default-features = false, features = ["std"] }
 
 [features]
 dev = ["rand", "postcard", "serde_json", "tracing/std", "serde-persistent-deserializer"]
-tokio = ["dep:tokio", "tokio-util"]
+tokio = ["dep:tokio", "tokio-util", "rand_chacha"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/manul/src/session/tokio.rs
+++ b/manul/src/session/tokio.rs
@@ -2,7 +2,8 @@
 
 use alloc::{format, sync::Arc, vec::Vec};
 
-use rand_core::CryptoRngCore;
+use rand_chacha::ChaCha20Rng;
+use rand_core::{CryptoRngCore, SeedableRng};
 use tokio::{sync::mpsc, task::JoinHandle};
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, trace};
@@ -234,14 +235,13 @@ where
         let destinations = session.message_destinations();
         let mut message_creation_tasks = Vec::new();
         for destination in destinations {
-            let rng = rng.clone();
             let session = session.clone();
             let my_id = my_id.clone();
             let outgoing_tx = outgoing_tx.clone();
             let destination = destination.clone();
+            let mut task_rng = ChaCha20Rng::from_rng(rng.clone()).map_err(|_| LocalError::new("Can't fork the RNG"))?;
             let message_creation = tokio::task::spawn_blocking(move || {
-                let mut rng = rng;
-                let (message, artifact) = session.make_message(&mut rng, &destination)?;
+                let (message, artifact) = session.make_message(&mut task_rng, &destination)?;
                 debug!("{my_id}: Sending a message to {destination:?}",);
                 let message_out = MessageOut {
                     session_id: session.session_id().clone(),

--- a/manul/src/session/tokio.rs
+++ b/manul/src/session/tokio.rs
@@ -239,6 +239,8 @@ where
             let my_id = my_id.clone();
             let outgoing_tx = outgoing_tx.clone();
             let destination = destination.clone();
+            // Spawned tasks must not share the same RNG state; we use the provided RNG to seed new ChaCha RNGs to
+            // ensure each task has access to unique randomness.
             let mut task_rng = ChaCha20Rng::from_rng(rng.clone()).map_err(|_| LocalError::new("Can't fork the RNG"))?;
             let message_creation = tokio::task::spawn_blocking(move || {
                 let (message, artifact) = session.make_message(&mut task_rng, &destination)?;


### PR DESCRIPTION
Any CSPRNG that is `Clone` and has internal state (e.g. all RNGs that are`SeedableRng`) is hazardous when used in spawned tokio tasks: each task will have an exact copy of the parent state and each use the same randomness (unless the CSPRNG author made sure this doesn't happen, which is not mandated by the type system, so we cannot know).

One commonly used CSPRNG is the `OsRng`, which is `Clone` but not `SeedablRng`. This particular CSPRNG is actually safe to clone and use in spawned tasks, because its state is fetched from the OS each time it is used (at the price of a performance hit).

Our parallel protocol runner requires `impl 'static + Clone + CryptoRngCore + Send`, which works well with `OsRng` and most other CSPRNGs, but we cannot re-seed it without also requiring `SeedableRng` (and thus forbid `OsRng`).

To square this circle this PR suggests we make an opinionated choice of creating new `ChaCha20` CSPRNGs for each task, seeded with the provided `impl CryptoRngCore`. It is a safe, performant and well-tested RNG that is unlikely to cause issues in the future.
 

Fixes #104
