### PR TITLE
Fix build warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,23 @@ jobs:
       - run: cargo build --target ${{ matrix.target }} --no-default-features
       - run: cargo build --target ${{ matrix.target }}
 
+  build-feature-powerset:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rust:
+          - stable
+        target:
+          - x86_64-unknown-linux-gnu
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@v1
+        with:
+          toolchain: ${{ matrix.rust }}
+          targets: ${{ matrix.target }}
+      - uses: taiki-e/install-action@cargo-hack
+      - run: env RUSTFLAGS="-D warnings" cargo hack build --target ${{ matrix.target }} --feature-powerset
+
   test-and-coverage:
     runs-on: ubuntu-latest
     steps:

--- a/manul/src/protocol.rs
+++ b/manul/src/protocol.rs
@@ -35,7 +35,7 @@ pub use round_id::{RoundId, RoundNum, TransitionInfo};
 pub use round_info::RoundInfo;
 
 pub(crate) use dyn_evidence::{BoxedProtocolError, SerializedProtocolError};
-pub(crate) use dyn_round::{Artifact, BoxedReceiveError, BoxedTypedRound, DynRound, Payload};
+pub(crate) use dyn_round::{Artifact, BoxedReceiveError, DynRound, Payload};
 pub(crate) use evidence::EvidenceProtocolMessage;
 pub(crate) use message::{
     DirectMessage, DirectMessageError, DynProtocolMessage, EchoBroadcast, EchoBroadcastError, NormalBroadcast,
@@ -46,3 +46,6 @@ pub(crate) use round::NoType;
 pub(crate) use round_id::GroupNum;
 pub(crate) use round_info::DynRoundInfo;
 pub(crate) use wire_format::BoxedFormat;
+
+#[cfg(any(test, feature = "dev"))]
+pub(crate) use dyn_round::BoxedTypedRound;

--- a/manul/src/protocol/dyn_round.rs
+++ b/manul/src/protocol/dyn_round.rs
@@ -1,8 +1,8 @@
 use alloc::{boxed::Box, collections::BTreeMap, format};
-use core::{
-    any::{Any, TypeId},
-    fmt::Debug,
-};
+use core::{any::Any, fmt::Debug};
+
+#[cfg(any(test, feature = "dev"))]
+use core::any::TypeId;
 
 use rand_core::CryptoRngCore;
 
@@ -118,6 +118,7 @@ impl<R> RoundWrapper<R> {
         Self { round }
     }
 
+    #[cfg(any(test, feature = "dev"))]
     pub fn into_inner(self) -> R {
         self.round
     }
@@ -262,6 +263,7 @@ impl<Id: PartyId, P: Protocol<Id>> BoxedRound<Id, P> {
         }
     }
 
+    #[cfg(any(test, feature = "dev"))]
     pub(crate) fn as_typed(&self) -> Result<&BoxedTypedRound<Id, P>, LocalError> {
         match &self.0 {
             BoxedRoundEnum::Dynamic(_boxed) => {
@@ -271,6 +273,7 @@ impl<Id: PartyId, P: Protocol<Id>> BoxedRound<Id, P> {
         }
     }
 
+    #[cfg(any(test, feature = "dev"))]
     pub(crate) fn into_typed(self) -> Result<BoxedTypedRound<Id, P>, LocalError> {
         match self.0 {
             BoxedRoundEnum::Dynamic(_boxed) => {
@@ -298,17 +301,20 @@ impl<Id: PartyId, P: Protocol<Id>> BoxedTypedRound<Id, P> {
     }
 
     /// Returns the type ID of the encapsulated `Round` implementor.
+    #[cfg(any(test, feature = "dev"))]
     pub(crate) fn type_id(&self) -> TypeId {
         self.0.as_ref().get_type_id()
     }
 
     /// Returns the type ID that [`type_id`] would return for an object created with [`new()`]
     /// given a round of type `R`.
+    #[cfg(any(test, feature = "dev"))]
     pub(crate) fn type_id_for<R: 'static + Round<Id, Protocol = P>>() -> TypeId {
         TypeId::of::<RoundWrapper<R>>()
     }
 
     /// Attempts to extract an object of a concrete type, preserving the original on failure.
+    #[cfg(any(test, feature = "dev"))]
     pub(crate) fn try_downcast<T: Round<Id>>(self) -> Result<T, Self> {
         if self.type_id() == TypeId::of::<RoundWrapper<T>>() {
             // Safety: This is safe since we just checked that we are casting to the correct type.
@@ -323,6 +329,7 @@ impl<Id: PartyId, P: Protocol<Id>> BoxedTypedRound<Id, P> {
     /// Attempts to extract an object of a concrete type.
     ///
     /// Fails if the wrapped type is not `T`.
+    #[cfg(any(test, feature = "dev"))]
     pub(crate) fn downcast<T: Round<Id>>(self) -> Result<T, LocalError> {
         self.try_downcast()
             .map_err(|_| LocalError::new(format!("Failed to downcast into type {}", core::any::type_name::<T>())))

--- a/manul/src/protocol/errors.rs
+++ b/manul/src/protocol/errors.rs
@@ -42,6 +42,7 @@ impl<Id, R> ReceiveError<Id, R>
 where
     R: Round<Id>,
 {
+    #[cfg(any(test, feature = "dev"))]
     pub(crate) fn map<NR, F>(self, f: F) -> ReceiveError<Id, NR>
     where
         F: Fn(R::ProtocolError) -> NR::ProtocolError,

--- a/manul/src/protocol/evidence.rs
+++ b/manul/src/protocol/evidence.rs
@@ -227,6 +227,7 @@ where
             .map_err(|err| EvidenceError::InvalidEvidence(format!("Error deserializing normal broadcast: {err}")))
     }
 
+    #[cfg(any(test, feature = "dev"))]
     pub(crate) fn into_round<NR>(self) -> EvidenceMessages<'a, Id, NR>
     where
         NR: Round<

--- a/manul/src/utils/type_id.rs
+++ b/manul/src/utils/type_id.rs
@@ -1,8 +1,10 @@
+#[cfg(any(test, feature = "dev"))]
 use core::any::TypeId;
 
 /// A dyn safe trait to get the type's ID.
 pub(crate) trait DynTypeId: 'static {
     /// Returns the type ID of the implementing type.
+    #[cfg(any(test, feature = "dev"))]
     fn get_type_id(&self) -> TypeId {
         TypeId::of::<Self>()
     }


### PR DESCRIPTION
Fixes #124 

The problem is that various type ID/downcast-related functionality is only used in `extend`, which is gated behind the `dev` feature now. Doesn't seem to be possible to cleanly extract all of these methods into the `dev` module, hence they have to be gated.

I added a `cargo hack` run to CI to detect future occurrences of this.